### PR TITLE
Video Audio and misc

### DIFF
--- a/FF8/Ffcc.cs
+++ b/FF8/Ffcc.cs
@@ -314,15 +314,18 @@ namespace FF8
             if (File.Exists(Outfile))
             {
                 wr = File.OpenRead(Outfile);
-                Ms = new ManualMemoryStream();
-                wr.CopyTo(Ms);
-                wr.Dispose();
+                if (wr.Length > 0)
+                {
+                    Ms = new ManualMemoryStream();
+                    wr.CopyTo(Ms);
+                    wr.Dispose();
 
-                se = new SoundEffect(Ms.ToArray(), Codec->sample_rate, (AudioChannels)Codec->channels);
-                see = se.CreateInstance();
-                //see.Play();
-                Ms.ManualDispose();
-                return true;
+                    se = new SoundEffect(Ms.ToArray(), Codec->sample_rate, (AudioChannels)Codec->channels);
+                    see = se.CreateInstance();
+                    //see.Play();
+                    Ms.ManualDispose();
+                    return true;
+                }
             }
 
             return false;
@@ -496,7 +499,6 @@ namespace FF8
                         {
                             die("Could not allocate samples");
                         }
-
                         int outSamples = 0;
                         fixed (byte** tmp = (byte*[])Frame->data)
                         {
@@ -532,7 +534,9 @@ namespace FF8
                             {
                                 die("Invalid buffer size");
                             }
-
+                            WritetoMs(convertedData, 0, buffer_size);
+                            continue;
+                            //encode
                             if (ffmpeg.avcodec_fill_audio_frame(SwrFrame,
                                      OutCodec->channels,
                                      OutCodec->sample_fmt,
@@ -542,7 +546,6 @@ namespace FF8
                             {
                                 die("Could not fill frame");
                             }
-
                             AVPacket outPacket;
                             ffmpeg.av_init_packet(&outPacket);
                             outPacket.data = null;
@@ -587,10 +590,10 @@ namespace FF8
         }
         private void ReadAll()
         {
-            if (SoundExistsAndReady())
-            {
-                return;
-            }
+            //if (SoundExistsAndReady())
+            //{
+            //    return;
+            //}
 
             Ms = new ManualMemoryStream();
             ReadAllnew();
@@ -619,7 +622,7 @@ namespace FF8
                 see.Play();
                 //}
             }
-            SoundExistsAndReady();
+            //SoundExistsAndReady();
             Ms.ManualDispose();
         }
         ~Ffcc()

--- a/FF8/Ffcc.cs
+++ b/FF8/Ffcc.cs
@@ -247,15 +247,17 @@ namespace FF8
                 try
                 {
                     // accepts streams with s16le wave files maybe more haven't tested everything.
-                    se = SoundEffect.FromStream(Ms); 
+                    se = SoundEffect.FromStream(Ms);
+                    see = se.CreateInstance();
+                    see.Play();
                 }
                 catch (ArgumentException)
                 {
                     // accepts s16le maybe more haven't tested everything.
                     se = new SoundEffect(Ms.ToArray(), 0, (int)Ms.Length, SwrFrame->sample_rate, (AudioChannels)Channels, 0, 0);
+                    see = se.CreateInstance();
+                    see.Play();
                 }
-                see = se.CreateInstance();
-                see.Play();
             }
 
             Ms.ManualDispose();
@@ -695,8 +697,8 @@ namespace FF8
             int bytes_per_sample = ffmpeg.av_get_bytes_per_sample(AVSampleFormat.AV_SAMPLE_FMT_S16) * nb_channels;
             bool got_packet = false;
             if ((Ret = ffmpeg.swr_convert_frame(Swr, SwrFrame, Frame)) >= 0)
-                Encode(SwrFrame, ref got_packet);
-                //WritetoMs(*OutFrame->extended_data, 0, OutFrame->nb_samples * bytes_per_sample);
+                //Encode(SwrFrame, ref got_packet);
+                WritetoMs(*SwrFrame->extended_data, 0, SwrFrame->nb_samples * bytes_per_sample);
             CheckRet();
         }
         private int Encode(AVFrame* OutFrame, ref bool got_packet)

--- a/FF8/Ffcc.cs
+++ b/FF8/Ffcc.cs
@@ -607,6 +607,7 @@ namespace FF8
                     //else
                     //{
                         Channels = ffmpeg.av_get_channel_layout_nb_channels(OutFrame->channel_layout);
+
                     //    //if(ffmpeg.av_sample_fmt_is_planar((AVSampleFormat)Frame->format)>0)
                     //    //{
                     //    //    byte*[] tmp = Frame->data;
@@ -614,13 +615,57 @@ namespace FF8
                     //    //    Ms.WriteByte(tmp[0][i]);
                     //    //}
                     //    // -4*32 sounds good but sound is cut off.
-                    ffmpeg.swr_convert_frame(Swr, OutFrame, Frame);
+
+
+                    //byte* convertedData = null;
+
+                    Ret = ffmpeg.av_samples_alloc(&convertedData,
+                        null,
+                        OutFrame->channels,
+                        Frame->nb_samples,
+                        (AVSampleFormat)OutFrame->format, 0);
                     CheckRet();
-                        byte*[] tmp = OutFrame->data;
-                        for (int i = 0; i < OutFrame->linesize[0]; i++)
-                        {
-                            Ms.WriteByte(tmp[0][i]);
-                        }
+
+                    int outSamples;
+                    byte*[] b = Frame->data;
+                    fixed (byte** t = b)
+                    {
+                        outSamples = ffmpeg.swr_convert(Swr, null, 0, t, Frame->nb_samples);
+                    }
+                    //byte*[] b = Frame->data;
+                    //fixed (byte** t = b)
+                    //{
+                    //    outSamples = ffmpeg.swr_convert(Swr, null, 0,t, Frame->nb_samples);
+                    //}
+                    //do
+                    //{
+                    //    outSamples = ffmpeg.swr_get_out_samples(Swr, 0);
+                    //    //if (outSamples <= Codec->frame_size * Codec->channels)
+                    //    //    break; // see comments, thanks to @dajuric for fixing this
+
+                    //    outSamples = ffmpeg.swr_convert(Swr,
+                    //        &convertedData,
+                    //        outSamples, null, 0);
+
+                    //    for (int i = 0; i < outSamples * 2 * 2; i++)
+                    //    {
+                    //        Ms.WriteByte(convertedData[i]);
+                    //    }
+                    //    //int buffer_size = ffmpeg.av_samples_get_buffer_size(null,
+                    //    //            OutFrame->channels,
+                    //    //            Frame->nb_samples,
+                    //    //            (AVSampleFormat) OutFrame->format,
+                    //    //            0);
+                    //    outSamples = ffmpeg.swr_get_out_samples(Swr, 0);
+                    //}
+                    //while (outSamples > 36);
+                    //ffmpeg.swr_convert_frame(Swr, OutFrame, Frame);
+                    //CheckRet();
+                    //    byte*[] tmp = OutFrame->data;
+                    //    for (int i = 0; i < OutFrame->linesize[0]; i++)
+                    //    {
+                    //        Ms.WriteByte(tmp[0][i]);
+                    //    }
                     //}
 
 

--- a/FF8/Ffcc.cs
+++ b/FF8/Ffcc.cs
@@ -92,8 +92,18 @@ namespace FF8
         public AVMediaType Media_Type { get; private set; }
         public enum FfccMode
         {
+            /// <summary>
+            /// Processes entire file at once and does something with output
+            /// </summary>
             PROCESS_ALL,
+            /// <summary>
+            /// State machine, functions in this call update to update current state.
+            /// And update decides what to do next.
+            /// </summary>
             STATE_MACH,
+            /// <summary>
+            /// Not Init some error happened that prevented the class from working
+            /// </summary>
             NOTINIT
         }
         public enum FfccState
@@ -167,7 +177,7 @@ namespace FF8
                         break;
                 }
             }
-            while (Mode == FfccMode.PROCESS_ALL && (State != FfccState.DONE || State != FfccState.WAITING));
+            while (!(Mode == FfccMode.PROCESS_ALL || State == FfccState.DONE || State == FfccState.WAITING));
             return ret;
         }
         private void ReadAll()

--- a/FF8/init_debugger_Audio.cs
+++ b/FF8/init_debugger_Audio.cs
@@ -277,7 +277,7 @@ namespace FF8
         }
         //callable test
 
-        public static byte[] ReadFullyByte(WaveStream stream)
+        public static byte[] ReadFullyByte(Stream stream)
         {
             // following formula goal is to calculate the number of bytes to make buffer. might be wrong.
             long size = stream.Length; // stream.Length should be in bytes. will error later if short.

--- a/FF8/init_debugger_Audio.cs
+++ b/FF8/init_debugger_Audio.cs
@@ -264,6 +264,8 @@ namespace FF8
             }
         }
 
+        
+
         public static void StopSound()
         {
             //waveout.Stop();
@@ -303,6 +305,16 @@ namespace FF8
 
             int read = stream.Read(buffer, 0, buffer.Length);
             return GetSamplesWaveData(buffer, read);
+        }
+        public static byte[] GetSamplesWaveData(byte[] samples, int samplesCount)
+        {
+            float[] f = new float[(samplesCount / sizeof(float))];
+            int i = 0;
+            for (int n = 0; n < samples.Length; n += sizeof(float))
+            {
+                f[i++] = BitConverter.ToSingle(samples, n);
+            }
+            return GetSamplesWaveData(f, samplesCount / sizeof(float));
         }
         public static byte[] GetSamplesWaveData(float[] samples, int samplesCount)
         { // converts 32 bit float samples to 16 bit pcm. I think :P

--- a/FF8/module_main_menu_debug.cs
+++ b/FF8/module_main_menu_debug.cs
@@ -1,9 +1,9 @@
-﻿using Microsoft.Xna.Framework.Graphics;
-using Microsoft.Xna.Framework;
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 using System;
-using System.Linq;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace FF8
 {
@@ -43,9 +43,14 @@ namespace FF8
             set
             {
                 if (value >= Memory.FieldHolder.fields.Length)
+                {
                     value = 0;
+                }
                 else if (value < 0)
+                {
                     value = Memory.FieldHolder.fields.Length - 1;
+                }
+
                 debug_fieldPointer = value;
                 Memory.FieldHolder.FieldID = (ushort)value;
                 debug_choosedField = Memory.FieldHolder.fields[value];
@@ -57,9 +62,14 @@ namespace FF8
             set
             {
                 if (value >= Module_movie_test.Movies.Count)
+                {
                     value = 0;
+                }
                 else if (value < 0)
-                    value = Module_movie_test.Movies.Count-1;
+                {
+                    value = Module_movie_test.Movies.Count - 1;
+                }
+
                 debug_moviePointer = value;
                 Module_movie_test.Index = value;
                 debug_choosedMovie = Path.GetFileNameWithoutExtension(Module_movie_test.Movies[value]);
@@ -91,12 +101,14 @@ namespace FF8
         private static void NewGameUpdate()
         {
             if (Fade > 0.0f)
+            {
                 return;
+            }
             /*reverse engineering notes:
-             * 
-             * we should happen to reset wm2field values
-             * also the basic party of Squall is now set: SG_PARTY_FIELD1 = 0, and other members are 0xFF
-             */
+* 
+* we should happen to reset wm2field values
+* also the basic party of Squall is now set: SG_PARTY_FIELD1 = 0, and other members are 0xFF
+*/
             FieldPointer = 74; //RE: startup stage ID is hardcoded. Probably we would want to change it for modding
             //the module changes to 1 now
             Module_field_debug.ResetField();
@@ -138,8 +150,11 @@ namespace FF8
             else if (Input.Button(Buttons.Okay))
             {
                 Input.ResetInputLimit();
-                if(Ditems.Sounds!=Dchoose)
+                if (Ditems.Sounds != Dchoose)
+                {
                     init_debugger_Audio.PlaySound(0);
+                }
+
                 switch (Dchoose)
                 {
                     case Ditems.Overture:
@@ -155,17 +170,27 @@ namespace FF8
                         break;
                     case Ditems.MusicNext:
                         if (Memory.MusicIndex >= ushort.MaxValue || Memory.MusicIndex >= Memory.dicMusic.Keys.Max())
+                        {
                             Memory.MusicIndex = 0;
+                        }
                         else
+                        {
                             Memory.MusicIndex++;
+                        }
+
                         init_debugger_Audio.PlayMusic();
                         break;
                     case Ditems.MusicPrev:
 
                         if (Memory.MusicIndex <= ushort.MinValue)
+                        {
                             Memory.MusicIndex = ushort.MaxValue;
+                        }
                         else
+                        {
                             Memory.MusicIndex--;
+                        }
+
                         init_debugger_Audio.PlayMusic();
                         break;
                     case Ditems.Battle:
@@ -198,10 +223,17 @@ namespace FF8
                 {
                     case Ditems.Sounds:
                         if (debug_choosedAudio > 0)
+                        {
                             debug_choosedAudio--;
+                        }
+
                         break;
                     case Ditems.Battle:
-                        if (debug_choosedBS <= 0) return;
+                        if (debug_choosedBS <= 0)
+                        {
+                            return;
+                        }
+
                         debug_choosedBS--;
                         break;
                     case Ditems.Feild:
@@ -220,11 +252,17 @@ namespace FF8
                 {
                     case Ditems.Sounds:
                         if (debug_choosedAudio < init_debugger_Audio.soundEntriesCount)
+                        {
                             debug_choosedAudio++;
+                        }
+
                         break;
                     case Ditems.Battle:
-                        if (debug_choosedBS < Memory.encounters.Length) 
+                        if (debug_choosedBS < Memory.encounters.Length)
+                        {
                             debug_choosedBS++;
+                        }
+
                         break;
 
                     case Ditems.Feild:
@@ -239,9 +277,14 @@ namespace FF8
         private static void LobbyUpdate()
         {
             if (start00 == null)
+            {
                 start00 = GetTexture(0);
+            }
+
             if (start01 == null)
+            {
                 start01 = GetTexture(1);
+            }
 
             if (Input.Button(Buttons.Down))
             {
@@ -341,7 +384,7 @@ namespace FF8
             Sounds,
             World
         }
-        private static Dictionary<Ditems, string> DebugMenu = new Dictionary<Ditems, string>()
+        private static readonly Dictionary<Ditems, string> DebugMenu = new Dictionary<Ditems, string>()
             {
                 { Ditems.Reset, "Reset Main Menu state"},
                 { Ditems.Overture, "Play Overture"},
@@ -394,9 +437,15 @@ namespace FF8
             float fScaleHeight = (float)Memory.graphics.GraphicsDevice.Viewport.Height / Memory.PreferredViewportHeight;
 
             if (start00 == null || start01 == null)
+            {
                 return;
+            }
+
             if (Fade < 1.0f && State != MainMenuStates.NewGameChoosed)
+            {
                 Fade += Memory.gameTime.ElapsedGameTime.Milliseconds / 1000.0f * 3;
+            }
+
             int vpWidth = Memory.graphics.GraphicsDevice.Viewport.Width;
             int vpHeight = Memory.graphics.GraphicsDevice.Viewport.Width;
             float zoom = 0.65f;

--- a/FF8/module_main_menu_debug.cs
+++ b/FF8/module_main_menu_debug.cs
@@ -147,6 +147,7 @@ namespace FF8
                         Fade = 0.0f;
                         State = MainMenuStates.MainLobby;
                         Module_overture_debug.ResetModule();
+                        Memory.module = Memory.MODULE_OVERTURE_DEBUG;
                         break;
                     case Ditems.Feild:
                         Module_field_debug.ResetField();

--- a/FF8/module_main_menu_debug.cs
+++ b/FF8/module_main_menu_debug.cs
@@ -36,7 +36,7 @@ namespace FF8
         private static string debug_choosedField = Memory.FieldHolder.fields[debug_fieldPointer];
 
         private static int debug_moviePointer = 0;
-        private static string debug_choosedMovie = Path.GetFileNameWithoutExtension(Module_movie_test.movies[debug_moviePointer]);
+        private static string debug_choosedMovie = Path.GetFileNameWithoutExtension(Module_movie_test.Movies[debug_moviePointer]);
         public static int FieldPointer
         {
             get { return debug_fieldPointer; }
@@ -56,13 +56,13 @@ namespace FF8
             get { return debug_moviePointer; }
             set
             {
-                if (value >= Module_movie_test.movies.Count)
+                if (value >= Module_movie_test.Movies.Count)
                     value = 0;
                 else if (value < 0)
-                    value = Module_movie_test.movies.Count-1;
+                    value = Module_movie_test.Movies.Count-1;
                 debug_moviePointer = value;
                 Module_movie_test.Index = value;
-                debug_choosedMovie = Path.GetFileNameWithoutExtension(Module_movie_test.movies[value]);
+                debug_choosedMovie = Path.GetFileNameWithoutExtension(Module_movie_test.Movies[value]);
             }
         }
 
@@ -102,7 +102,7 @@ namespace FF8
             Module_field_debug.ResetField();
 
             Module_movie_test.Index = 30;
-            Module_movie_test.returnState = Memory.MODULE_FIELD_DEBUG;
+            Module_movie_test.ReturnState = Memory.MODULE_FIELD_DEBUG;
             Memory.module = Memory.MODULE_MOVIETEST;
         }
 
@@ -182,7 +182,7 @@ namespace FF8
                         Fade = 0.0f;
                         MoviePointer = MoviePointer; //makes movieindex in player match the moviepointer, it is set when ever this is.
                         Memory.module = Memory.MODULE_MOVIETEST;
-                        Module_movie_test.movieState = 0;
+                        Module_movie_test.MovieState = 0;
                         break;
                     case Ditems.World:
                         Memory.module = Memory.MODULE_WORLD_DEBUG;

--- a/FF8/module_movie_test.cs
+++ b/FF8/module_movie_test.cs
@@ -96,9 +96,9 @@ namespace FF8
             //vfr.Open(Path.Combine(movieDirs[0] , "disc02_25h.avi"));
             //vfr.Open(Path.Combine(movieDirs[0], "disc00_30h.avi"));
 
-            Ffccaudio = new Ffcc(@"c:\eyes_on_me.wav", AVMediaType.AVMEDIA_TYPE_AUDIO, Ffcc.FfccMode.PROCESS_ALL);
+            //Ffccaudio = new Ffcc(@"c:\eyes_on_me.wav", AVMediaType.AVMEDIA_TYPE_AUDIO, Ffcc.FfccMode.PROCESS_ALL);
 
-            //Ffccaudio = new Ffcc(Movies[Index], AVMediaType.AVMEDIA_TYPE_AUDIO, Ffcc.FfccMode.PROCESS_ALL);
+            Ffccaudio = new Ffcc(Movies[Index], AVMediaType.AVMEDIA_TYPE_AUDIO, Ffcc.FfccMode.PROCESS_ALL);
             Ffccvideo = new Ffcc(Movies[Index], AVMediaType.AVMEDIA_TYPE_VIDEO, Ffcc.FfccMode.STATE_MACH);
             FPS = Ffccvideo.FPS;
             try

--- a/FF8/module_movie_test.cs
+++ b/FF8/module_movie_test.cs
@@ -8,6 +8,8 @@ using System.Runtime.InteropServices;
 using System.Collections.Generic;
 using FFmpeg.AutoGen;
 using Microsoft.Xna.Framework.Input;
+using Microsoft.Xna.Framework.Audio;
+using NAudio.Wave;
 
 namespace FF8
 {
@@ -97,16 +99,24 @@ namespace FF8
 
 
         // The flush packet is a non-null packet with size 0 and data null
-
+        private static SoundEffectInstance see;
         private static void InitMovie()
         {
 
             //vfr.Open(Path.Combine(movieDirs[0] , "disc02_25h.avi"));
             //vfr.Open(Path.Combine(movieDirs[0], "disc00_30h.avi"));
 
-            Ffccaudio = new Ffcc(@"c:\eyes_on_me.wav", AVMediaType.AVMEDIA_TYPE_AUDIO, Ffcc.FfccMode.PROCESS_ALL);
+            //Ffccaudio = new Ffcc(@"c:\eyes_on_me.wav", AVMediaType.AVMEDIA_TYPE_AUDIO, Ffcc.FfccMode.PROCESS_ALL);
 
-            //Ffccaudio = new Ffcc(Movies[Index], AVMediaType.AVMEDIA_TYPE_AUDIO, Ffcc.FfccMode.PROCESS_ALL);
+            Ffccaudio = new Ffcc(Movies[Index], AVMediaType.AVMEDIA_TYPE_AUDIO, Ffcc.FfccMode.PROCESS_ALL);
+            //using (FileStream fs =File.OpenRead(@"C:\Users\pcvii\source\repos\ConsoleApp1\ConsoleApp1\bin\Debug\audio.wav"))
+            //{
+            //    SoundEffect se = new SoundEffect(init_debugger_Audio.ReadFullyByte(fs),44100,AudioChannels.Stereo);
+            //    //SoundEffect se = SoundEffect.FromStream(fs);
+            //            see = se.CreateInstance();
+            //            see.Play();
+                    
+            //}
             Ffccvideo = new Ffcc(Movies[Index], AVMediaType.AVMEDIA_TYPE_VIDEO, Ffcc.FfccMode.STATE_MACH);
             FPS = Ffccvideo.FPS;
             try

--- a/FF8/module_movie_test.cs
+++ b/FF8/module_movie_test.cs
@@ -96,7 +96,9 @@ namespace FF8
             //vfr.Open(Path.Combine(movieDirs[0] , "disc02_25h.avi"));
             //vfr.Open(Path.Combine(movieDirs[0], "disc00_30h.avi"));
 
-            Ffccaudio = new Ffcc(Movies[Index], AVMediaType.AVMEDIA_TYPE_AUDIO, Ffcc.FfccMode.PROCESS_ALL);
+            Ffccaudio = new Ffcc(@"c:\eyes_on_me.wav", AVMediaType.AVMEDIA_TYPE_AUDIO, Ffcc.FfccMode.PROCESS_ALL);
+
+            //Ffccaudio = new Ffcc(Movies[Index], AVMediaType.AVMEDIA_TYPE_AUDIO, Ffcc.FfccMode.PROCESS_ALL);
             Ffccvideo = new Ffcc(Movies[Index], AVMediaType.AVMEDIA_TYPE_VIDEO, Ffcc.FfccMode.STATE_MACH);
             FPS = Ffccvideo.FPS;
             try

--- a/FF8/module_movie_test.cs
+++ b/FF8/module_movie_test.cs
@@ -7,6 +7,7 @@ using System.Drawing.Imaging;
 using System.Runtime.InteropServices;
 using System.Collections.Generic;
 using FFmpeg.AutoGen;
+using Microsoft.Xna.Framework.Input;
 
 namespace FF8
 {
@@ -57,6 +58,13 @@ namespace FF8
 
         internal static void Update()
         {
+            if (Input.Button(Buttons.Okay) || Input.Button(Buttons.Cancel) || Input.Button(Keys.Space))
+            {
+                Input.ResetInputLimit();
+                //init_debugger_Audio.StopAudio();
+                //Memory.module = Memory.MODULE_MAINMENU_DEBUG;
+                MovieState = STATE_RETURN;
+            }
             switch (MovieState)
             {
                 case STATE_INIT:
@@ -96,9 +104,9 @@ namespace FF8
             //vfr.Open(Path.Combine(movieDirs[0] , "disc02_25h.avi"));
             //vfr.Open(Path.Combine(movieDirs[0], "disc00_30h.avi"));
 
-            //Ffccaudio = new Ffcc(@"c:\eyes_on_me.wav", AVMediaType.AVMEDIA_TYPE_AUDIO, Ffcc.FfccMode.PROCESS_ALL);
+            Ffccaudio = new Ffcc(@"c:\eyes_on_me.wav", AVMediaType.AVMEDIA_TYPE_AUDIO, Ffcc.FfccMode.PROCESS_ALL);
 
-            Ffccaudio = new Ffcc(Movies[Index], AVMediaType.AVMEDIA_TYPE_AUDIO, Ffcc.FfccMode.PROCESS_ALL);
+            //Ffccaudio = new Ffcc(Movies[Index], AVMediaType.AVMEDIA_TYPE_AUDIO, Ffcc.FfccMode.PROCESS_ALL);
             Ffccvideo = new Ffcc(Movies[Index], AVMediaType.AVMEDIA_TYPE_VIDEO, Ffcc.FfccMode.STATE_MACH);
             FPS = Ffccvideo.FPS;
             try

--- a/FF8/module_movie_test.cs
+++ b/FF8/module_movie_test.cs
@@ -1,15 +1,12 @@
 ﻿
-using System;
-using System.IO;
-using System.Drawing;
-using Microsoft.Xna.Framework.Graphics;
-using System.Drawing.Imaging;
-using System.Runtime.InteropServices;
-using System.Collections.Generic;
 using FFmpeg.AutoGen;
-using Microsoft.Xna.Framework.Input;
 using Microsoft.Xna.Framework.Audio;
-using NAudio.Wave;
+using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework.Input;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
 
 namespace FF8
 {
@@ -102,7 +99,7 @@ namespace FF8
 
 
         // The flush packet is a non-null packet with size 0 and data null
-        private static SoundEffectInstance see;
+        private static readonly SoundEffectInstance see;
         private static void InitMovie()
         {
 
@@ -118,12 +115,12 @@ namespace FF8
             //    //SoundEffect se = SoundEffect.FromStream(fs);
             //            see = se.CreateInstance();
             //            see.Play();
-                    
+
             //}
             Ffccvideo = new Ffcc(Movies[Index], AVMediaType.AVMEDIA_TYPE_VIDEO, Ffcc.FfccMode.STATE_MACH);
             FPS = Ffccvideo.FPS;
-            if(FPS == 0)
-            { 
+            if (FPS == 0)
+            {
                 TextWriter errorWriter = Console.Error;
                 errorWriter.WriteLine("Can not calc FPS, possibly FFMPEG dlls are missing or an error has occured");
                 MovieState = STATE_RETURN;
@@ -164,7 +161,10 @@ namespace FF8
             ClearScreen();
             Memory.SpriteBatchStartStencil();
             if (LastFrame != null)
+            {
                 Memory.spriteBatch.Draw(LastFrame, new Microsoft.Xna.Framework.Rectangle(0, 0, Memory.graphics.PreferredBackBufferWidth, Memory.graphics.PreferredBackBufferHeight), Microsoft.Xna.Framework.Color.White);
+            }
+
             Memory.SpriteBatchEnd();
             //movieState = STATE_INIT;
             //Memory.module = Memory.MODULE_BATTLE_DEBUG;

--- a/FF8/module_overture_debug.cs
+++ b/FF8/module_overture_debug.cs
@@ -117,7 +117,7 @@ namespace FF8
                     break;
                 case OvertureInternalModule._4Squaresoft:
                     internalModule = OvertureInternalModule._0InitSound;
-                    Module_movie_test.Index = 0;//103;
+                    Module_movie_test.Index = 103;//103;
                     Module_movie_test.ReturnState = Memory.MODULE_OVERTURE_DEBUG;
                     Memory.module = Memory.MODULE_MOVIETEST;
                     break;

--- a/FF8/module_overture_debug.cs
+++ b/FF8/module_overture_debug.cs
@@ -3,11 +3,6 @@ using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 using System;
 using System.Linq;
-using NAudio.Wave;
-using NAudio;
-using NAudio.Vorbis;
-using Microsoft.Xna.Framework.Audio;
-using System.IO;
 
 namespace FF8
 {
@@ -81,7 +76,7 @@ namespace FF8
         }
         private static void InitSound()
         {
-            Memory.MusicIndex =  79;//79; //Overture
+            Memory.MusicIndex = 79;//79; //Overture
             init_debugger_Audio.PlayMusic();
             Memory.MusicIndex = ushort.MaxValue; // reset pos after playing overture; will loop back to start if push next
 
@@ -89,12 +84,15 @@ namespace FF8
             white = new Texture2D(Memory.graphics.GraphicsDevice, 4, 4, false, SurfaceFormat.Color);
             byte[] whiteBuffer = new byte[16];
             for (int i = 0; i < 16; i++)
+            {
                 whiteBuffer[i] = 255;
+            }
+
             internalModule++;
         }
         internal static void Draw()
         {
-            if (Input.Button(Buttons.Okay)||Input.Button(Buttons.Cancel)||Input.Button(Keys.Space))
+            if (Input.Button(Buttons.Okay) || Input.Button(Buttons.Cancel) || Input.Button(Keys.Space))
             {
                 Input.ResetInputLimit();
                 init_debugger_Audio.StopAudio();
@@ -128,17 +126,28 @@ namespace FF8
         {
             //fade to white
             if (!bWaitingSplash)
+            {
                 Memory.graphics.GraphicsDevice.Clear(Color.White);
+            }
             else
+            {
                 Memory.graphics.GraphicsDevice.Clear(Color.Black);
+            }
+
             Memory.SpriteBatchStartAlpha();
             Memory.spriteBatch.Draw(splashTex, new Microsoft.Xna.Framework.Rectangle(0, 0, Memory.graphics.GraphicsDevice.Viewport.Width, Memory.graphics.GraphicsDevice.Viewport.Height),
                 new Microsoft.Xna.Framework.Rectangle(0, 0, splashTex.Width, splashTex.Height)
                 , Color.White * Fade);
             if (bFadingIn)
+            {
                 Fade += Memory.gameTime.ElapsedGameTime.Milliseconds / 5000.0f;
+            }
+
             if (bFadingOut)
+            {
                 Fade -= Memory.gameTime.ElapsedGameTime.Milliseconds / 2000.0f;
+            }
+
             if (Fade < 0.0f)
             {
                 bFadingIn = true;
@@ -146,7 +155,10 @@ namespace FF8
                 bFadingOut = false;
             }
             if (bFadingIn && Fade > 1.0f && !bWaitingSplash)
+            {
                 internalTimer += Memory.gameTime.ElapsedGameTime.Milliseconds / 1000.0f;
+            }
+
             if (internalTimer > 5.0f)
             {
                 bWaitingSplash = true;
@@ -164,7 +176,10 @@ namespace FF8
         private static void DrawSplash()
         {
             if (splashTex == null)
+            {
                 return;
+            }
+
             Memory.SpriteBatchStartAlpha();
             Memory.spriteBatch.Draw(splashTex, new Microsoft.Xna.Framework.Rectangle(0, 0, Memory.graphics.GraphicsDevice.Viewport.Width, Memory.graphics.GraphicsDevice.Viewport.Height),
                 new Microsoft.Xna.Framework.Rectangle(0, 0, splashTex.Width, splashTex.Height)
@@ -175,9 +190,15 @@ namespace FF8
         internal static void SplashUpdate(ref int _splashIndex)
         {
             if (aw == null)
+            {
                 aw = new ArchiveWorker(Memory.Archives.A_MAIN);
+            }
+
             if (splashTex == null)
+            {
                 ReadSplash();
+            }
+
             if (bFadingIn)
             {
                 Fade += Memory.gameTime.ElapsedGameTime.Milliseconds / 1000.0f * 2f;
@@ -208,8 +229,14 @@ namespace FF8
                     Fade = 0.0f;
                     _splashIndex++;
                     if (bNames)
+                    {
                         splashName++;
-                    else splashLoop++;
+                    }
+                    else
+                    {
+                        splashLoop++;
+                    }
+
                     if (_splashIndex > 1)
                     {
                         bNames = !bNames;
@@ -250,13 +277,21 @@ namespace FF8
         {
             if (!bLogo)
             {
-                if (splashName > 0x0f) return;
+                if (splashName > 0x0f)
+                {
+                    return;
+                }
+
                 string[] lof = aw.GetListOfFiles();
                 string fileName;
                 if (bNames)
+                {
                     fileName = lof.First(x => x.ToLower().Contains($"{names}{splashName.ToString("D2")}"));
+                }
                 else
+                {
                     fileName = lof.First(x => x.ToLower().Contains($"{loops}{splashLoop.ToString("D2")}"));
+                }
 
                 byte[] buffer = ArchiveWorker.GetBinaryFile(Memory.Archives.A_MAIN, fileName);
                 uint uncompSize = BitConverter.ToUInt32(buffer, 0);
@@ -267,7 +302,11 @@ namespace FF8
                 int innerBufferIndex = 0;
                 for (int i = 0; i < rgbBuffer.Length; i += 4)
                 {
-                    if (innerBufferIndex + 1 >= buffer.Length) break;
+                    if (innerBufferIndex + 1 >= buffer.Length)
+                    {
+                        break;
+                    }
+
                     ushort pixel = (ushort)((buffer[innerBufferIndex + 1] << 8) | buffer[innerBufferIndex]);
                     byte red = (byte)((pixel) & 0x1F);
                     byte green = (byte)((pixel >> 5) & 0x1F);
@@ -299,7 +338,11 @@ namespace FF8
                 int innerBufferIndex = 0;
                 for (int i = 0; i < rgbBuffer.Length; i += 4)
                 {
-                    if (innerBufferIndex + 1 >= buffer.Length) break;
+                    if (innerBufferIndex + 1 >= buffer.Length)
+                    {
+                        break;
+                    }
+
                     ushort pixel = (ushort)((buffer[innerBufferIndex + 1] << 8) | buffer[innerBufferIndex]);
                     byte red = (byte)((pixel) & 0x1F);
                     byte green = (byte)((pixel >> 5) & 0x1F);

--- a/FF8/module_overture_debug.cs
+++ b/FF8/module_overture_debug.cs
@@ -117,7 +117,7 @@ namespace FF8
                     break;
                 case OvertureInternalModule._4Squaresoft:
                     internalModule = OvertureInternalModule._0InitSound;
-                    Module_movie_test.Index = 103;
+                    Module_movie_test.Index = 0;//103;
                     Module_movie_test.ReturnState = Memory.MODULE_OVERTURE_DEBUG;
                     Memory.module = Memory.MODULE_MOVIETEST;
                     break;

--- a/FF8/module_overture_debug.cs
+++ b/FF8/module_overture_debug.cs
@@ -67,7 +67,7 @@ namespace FF8
             Memory.spriteBatch.GraphicsDevice.Clear(Color.Black);
 
             internalModule = OvertureInternalModule._4Squaresoft;
-            Module_movie_test.returnState = Memory.MODULE_OVERTURE_DEBUG;
+            Module_movie_test.ReturnState = Memory.MODULE_OVERTURE_DEBUG;
         }
         private static void WaitForFirst()
         {
@@ -118,7 +118,7 @@ namespace FF8
                 case OvertureInternalModule._4Squaresoft:
                     internalModule = OvertureInternalModule._0InitSound;
                     Module_movie_test.Index = 103;
-                    Module_movie_test.returnState = Memory.MODULE_OVERTURE_DEBUG;
+                    Module_movie_test.ReturnState = Memory.MODULE_OVERTURE_DEBUG;
                     Memory.module = Memory.MODULE_MOVIETEST;
                     break;
             }

--- a/FF8/module_overture_debug.cs
+++ b/FF8/module_overture_debug.cs
@@ -65,7 +65,7 @@ namespace FF8
             bFadingOut = false;
             Fade = 0;
             Memory.spriteBatch.GraphicsDevice.Clear(Color.Black);
-
+            Memory.module = Memory.MODULE_OVERTURE_DEBUG;
             internalModule = OvertureInternalModule._4Squaresoft;
             Module_movie_test.ReturnState = Memory.MODULE_OVERTURE_DEBUG;
         }


### PR DESCRIPTION
Most of this is getting audio playback to the Ffcc class (ffmpeg custom class)

Fixed a few other bugs:
overture from debug not working
midi playback pulling from wrong structure.
fps delay code was wrong. couldn't really tell till you got audio playing next to it :P
fixed the RaW is missing but not checking for directory before referencing it. 

The new code is capable of writing the sounds to the drive as well. defaults to %temp%/filenamenoext.pcm.

Most of this week was trying to fix the wrong thing. (does this work x 1000.) It was the decode function all this time at least mostly. 
I was going to add one last change to allow pausing of the videos but it didn't work audio kept playing though it was glitched while playing and paused.