### PR TITLE
small update 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@ packages/*
 *.exe
 *.pdb 
 AForge.*
-FF8/Content/obj/DesktopGL/Content/.mgstats
+FF8/Content/obj/*

--- a/FF8/FF8.csproj
+++ b/FF8/FF8.csproj
@@ -68,7 +68,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'DebugLinux|x86'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\x86\DebugLinux\</OutputPath>
-    <DefineConstants>DEBUG;_WINDOWS</DefineConstants>
+    <DefineConstants>_WINDOWS;DEBUG</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugType>full</DebugType>
     <PlatformTarget>x86</PlatformTarget>

--- a/FF8/Ffcc.cs
+++ b/FF8/Ffcc.cs
@@ -289,7 +289,11 @@ namespace FF8
                         PrepareScaler();
                         break;
                     case FfccState.READ://Enters waiting state unless we want to process all now.
-                        State = Mode == FfccMode.PROCESS_ALL ? FfccState.READALL : FfccState.WAITING;
+                        State = Mode == FfccMode.PROCESS_ALL ? FfccState.READALL : FfccState.READONE; 
+                        //READONE here makes it grab one video frame and precaches audio to it's limit.
+                        //WAITING here makes it wait till GetFrame() is called.
+                        //READALL just processes the whole audio stream (memoryleaky), not ment for video
+                        //Currently video will just saves all the frames to bmp in temp folder on READALL.
                         break;
                     case FfccState.READALL:
                         State = FfccState.DONE;

--- a/FF8/init_debugger_Audio.cs
+++ b/FF8/init_debugger_Audio.cs
@@ -363,7 +363,7 @@ namespace FF8
         }
         internal static void Update()
         {
-            while (ffccMusic != null && !ffccMusic.AheadFrame())
+            if (ffccMusic != null && !ffccMusic.AheadFrame())
             {
                 ffccMusic.GetFrame();
             }

--- a/FF8/init_debugger_Audio.cs
+++ b/FF8/init_debugger_Audio.cs
@@ -467,7 +467,6 @@ namespace FF8
             {
                 case ".ogg":
                     ffccMusic = new Ffcc(pt, FFmpeg.AutoGen.AVMediaType.AVMEDIA_TYPE_AUDIO, Ffcc.FfccMode.STATE_MACH);
-                    ffccMusic.GetFrame();
                     ffccMusic.PlaySound();
                     break;
                 case ".sgt":

--- a/FF8/module_battle_Debug.cs
+++ b/FF8/module_battle_Debug.cs
@@ -236,19 +236,36 @@ namespace FF8
                 }
             }
         }
+
+        const float defaultmaxMoveSpeed = 1f;
+        const float MoveSpeedChange = 1f;
+        static float maxMoveSpeed = defaultmaxMoveSpeed;
+        const float maxLookSpeed = 0.25f;
         public static void FPSCamera()
         {
             #region FPScamera
-            float x_shift = 0.0f;
-            float y_shift = 0.0f;
+            float x_shift = 0.0f, y_shift = 0.0f, leftdistX = 0.0f, leftdistY = 0.0f;
+
+            //speedcontrols
+            //+ to increase
+            //- to decrease
+            //* to reset            
+            if (Input.Button(Keys.OemPlus) || Input.Button(Keys.Add))
+            {
+                maxMoveSpeed += MoveSpeedChange;
+            }
+            if (Input.Button(Keys.OemMinus) || Input.Button(Keys.Subtract))
+            {
+                maxMoveSpeed -= MoveSpeedChange;
+                if (maxMoveSpeed < defaultmaxMoveSpeed) maxMoveSpeed = defaultmaxMoveSpeed;
+            }
+            if (Input.Button(Keys.Multiply)) maxMoveSpeed = defaultmaxMoveSpeed;
 
             //speed is effected by the milliseconds between frames. so alittle goes a long way. :P
-            float maxMoveSpeed = 1f;
-            float maxLookSpeed = 0.25f;
             x_shift = Input.Distance(Buttons.MouseXjoy, maxLookSpeed);
             y_shift = Input.Distance(Buttons.MouseYjoy, maxLookSpeed);
-            float leftdistX = Math.Abs(Input.Distance(Buttons.LeftStickX, maxMoveSpeed));
-            float leftdistY = Math.Abs(Input.Distance(Buttons.LeftStickY, maxMoveSpeed));
+            leftdistX = Math.Abs(Input.Distance(Buttons.LeftStickX, maxMoveSpeed));
+            leftdistY = Math.Abs(Input.Distance(Buttons.LeftStickY, maxMoveSpeed));
             x_shift += Input.Distance(Buttons.RightStickX, maxLookSpeed);
             y_shift += Input.Distance(Buttons.RightStickY, maxLookSpeed);
             Yshift -= y_shift;
@@ -262,6 +279,7 @@ namespace FF8
             {
                 leftdistX = Input.Distance(maxMoveSpeed);
             }
+
             if (Input.Button(Buttons.Up))//(Keyboard.GetState().IsKeyDown(Keys.W) || GamePad.GetState(PlayerIndex.One).ThumbSticks.Left.Y > 0.0f)
             {
                 camPosition.X += (float)Math.Cos(MathHelper.ToRadians(degrees)) * leftdistY / 10;

--- a/FF8/module_movie_test.cs
+++ b/FF8/module_movie_test.cs
@@ -4,7 +4,6 @@ using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.IO;
 
 namespace FF8
@@ -86,8 +85,6 @@ namespace FF8
                 case STATE_INIT:
                     MovieState++;
                     InitMovie();
-                    if (Ffccaudio != null)
-                        Ffccaudio.GetFrame(); // primes the audio buffer with one frame of data
                     break;
                 case STATE_CLEAR:
                     break;
@@ -214,12 +211,10 @@ namespace FF8
         //private static Bitmap Frame { get => frame; set { lastframe = frame; frame = value; } }
         private static void PlayingDraw()
         {
-            if (frameTex == null || Ffccvideo.BehindFrame())
-            {
-                MsElapsed = 0;
 
-                int ret = Ffccvideo.GetFrame();
-                if (ret < 0)
+            if (Ffccvideo.BehindFrame())
+            {
+                if (Ffccvideo.GetFrame() < 0)
                 {
                     MovieState = STATE_FINISHED;
                     return;
@@ -229,10 +224,16 @@ namespace FF8
                     frameTex.Dispose();
                     GC.Collect();
                     GC.WaitForPendingFinalizers();
+                    frameTex = null;
                 }
-
+            }
+            if (frameTex == null)
+            {
                 frameTex = Ffccvideo.FrameToTexture2D();
             }
+
+
+
 
             //draw frame;
             Memory.SpriteBatchStartStencil();

--- a/FF8/module_movie_test.cs
+++ b/FF8/module_movie_test.cs
@@ -41,7 +41,7 @@ namespace FF8
             }
         }
 
-        private static Bitmap Frame { get; set; } = null;
+        //private static Bitmap Frame { get; set; } = null;
         private static Ffcc Ffccvideo { get; set; } = null;
         private static Texture2D frameTex { get; set; } = null;
         private static Ffcc Ffccaudio { get; set; } = null;
@@ -92,7 +92,7 @@ namespace FF8
                 case STATE_CLEAR:
                     break;
                 case STATE_PLAYING:
-                    while (Ffccaudio != null && !Ffccaudio.AheadFrame())
+                    if (Ffccaudio != null && !Ffccaudio.AheadFrame())
                     {
                         // if we are behind the timer get the next frame of audio.
                         Ffccaudio.GetFrame(); //might not be doing anything
@@ -144,11 +144,6 @@ namespace FF8
             }
 
             frameTex = null;
-            if (Frame != null)
-            {
-                Frame.Dispose();
-            }
-            Frame = null;
             GC.Collect();
         }
 
@@ -204,13 +199,14 @@ namespace FF8
         private static void FinishedDraw()
         {
             ClearScreen();
-            Memory.SpriteBatchStartStencil();
+
             if (frameTex != null)
             {
+                //Memory.SpriteBatchStartStencil();
+                Memory.SpriteBatchStartAlpha();
                 Memory.spriteBatch.Draw(frameTex, new Microsoft.Xna.Framework.Rectangle(0, 0, Memory.graphics.PreferredBackBufferWidth, Memory.graphics.PreferredBackBufferHeight), Microsoft.Xna.Framework.Color.White);
+                Memory.SpriteBatchEnd();
             }
-
-            Memory.SpriteBatchEnd();
             //movieState = STATE_INIT;
             //Memory.module = Memory.MODULE_BATTLE_DEBUG;
         }

--- a/FF8/module_world_debug.cs
+++ b/FF8/module_world_debug.cs
@@ -326,19 +326,35 @@ namespace FF8
             br.Dispose();
             ms.Dispose();
         }
+        const float defaultmaxMoveSpeed = 1f;
+        const float MoveSpeedChange = 1f;
+        static float maxMoveSpeed = defaultmaxMoveSpeed;
+        const float maxLookSpeed = 0.25f;
         public static void FPSCamera()
-        { //copied from module_battle_debug. Wondering how the two functions could be merged somehow so there isn't duplicate code.
+        {
             #region FPScamera
-            float x_shift = 0.0f;
-            float y_shift = 0.0f;
+            float x_shift = 0.0f, y_shift = 0.0f, leftdistX = 0.0f, leftdistY = 0.0f;
+
+            //speedcontrols
+            //+ to increase
+            //- to decrease
+            //* to reset            
+            if (Input.Button(Keys.OemPlus) || Input.Button(Keys.Add))
+            {
+                maxMoveSpeed += MoveSpeedChange;
+            }
+            if (Input.Button(Keys.OemMinus) || Input.Button(Keys.Subtract))
+            {
+                maxMoveSpeed -= MoveSpeedChange;
+                if (maxMoveSpeed < defaultmaxMoveSpeed) maxMoveSpeed = defaultmaxMoveSpeed;
+            }
+            if (Input.Button(Keys.Multiply)) maxMoveSpeed = defaultmaxMoveSpeed;
 
             //speed is effected by the milliseconds between frames. so alittle goes a long way. :P
-            float maxMoveSpeed = 1f;
-            float maxLookSpeed = 0.25f;
             x_shift = Input.Distance(Buttons.MouseXjoy, maxLookSpeed);
             y_shift = Input.Distance(Buttons.MouseYjoy, maxLookSpeed);
-            float leftdistX = Math.Abs(Input.Distance(Buttons.LeftStickX, maxMoveSpeed));
-            float leftdistY = Math.Abs(Input.Distance(Buttons.LeftStickY, maxMoveSpeed));
+            leftdistX = Math.Abs(Input.Distance(Buttons.LeftStickX, maxMoveSpeed));
+            leftdistY = Math.Abs(Input.Distance(Buttons.LeftStickY, maxMoveSpeed));
             x_shift += Input.Distance(Buttons.RightStickX, maxLookSpeed);
             y_shift += Input.Distance(Buttons.RightStickY, maxLookSpeed);
             Yshift -= y_shift;
@@ -352,6 +368,7 @@ namespace FF8
             {
                 leftdistX = Input.Distance(maxMoveSpeed);
             }
+
             if (Input.Button(Buttons.Up))//(Keyboard.GetState().IsKeyDown(Keys.W) || GamePad.GetState(PlayerIndex.One).ThumbSticks.Left.Y > 0.0f)
             {
                 camPosition.X += (float)Math.Cos(MathHelper.ToRadians(degrees)) * leftdistY / 10;


### PR DESCRIPTION
We had a request on the forums last week to increase speed on world map. So I added speed controls

I tweaked ffcc to preload the audio and first frame of video when "new ffcc" is used. instead of waiting for the first GetFrame call. so i could remove the extra getframe before play.