### PR TITLE
new _X64 for 64bit

### DIFF
--- a/FF8.sln
+++ b/FF8.sln
@@ -11,6 +11,8 @@ Global
 		Debug|x86 = Debug|x86
 		DebugLinux|x64 = DebugLinux|x64
 		DebugLinux|x86 = DebugLinux|x86
+		DebugWindows|x64 = DebugWindows|x64
+		DebugWindows|x86 = DebugWindows|x86
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
@@ -23,6 +25,10 @@ Global
 		{E23A12F6-73DC-4933-903B-2DC0765ED19B}.DebugLinux|x64.Build.0 = DebugLinux|x64
 		{E23A12F6-73DC-4933-903B-2DC0765ED19B}.DebugLinux|x86.ActiveCfg = DebugLinux|x86
 		{E23A12F6-73DC-4933-903B-2DC0765ED19B}.DebugLinux|x86.Build.0 = DebugLinux|x86
+		{E23A12F6-73DC-4933-903B-2DC0765ED19B}.DebugWindows|x64.ActiveCfg = DebugWindows|x64
+		{E23A12F6-73DC-4933-903B-2DC0765ED19B}.DebugWindows|x64.Build.0 = DebugWindows|x64
+		{E23A12F6-73DC-4933-903B-2DC0765ED19B}.DebugWindows|x86.ActiveCfg = DebugWindows|x86
+		{E23A12F6-73DC-4933-903B-2DC0765ED19B}.DebugWindows|x86.Build.0 = DebugWindows|x86
 		{E23A12F6-73DC-4933-903B-2DC0765ED19B}.Release|x64.ActiveCfg = Release|x64
 		{E23A12F6-73DC-4933-903B-2DC0765ED19B}.Release|x64.Build.0 = Release|x64
 		{E23A12F6-73DC-4933-903B-2DC0765ED19B}.Release|x86.ActiveCfg = Release|x86

--- a/FF8/FF8.csproj
+++ b/FF8/FF8.csproj
@@ -53,7 +53,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\$(MonoGamePlatform)\$(Platform)\$(Configuration)\</OutputPath>
-    <DefineConstants>TRACE;WINDOWS</DefineConstants>
+    <DefineConstants>_WINDOWS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <LangVersion>7.2</LangVersion>
@@ -68,7 +68,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'DebugLinux|x86'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\x86\DebugLinux\</OutputPath>
-    <DefineConstants>_WINDOWS;DEBUG</DefineConstants>
+    <DefineConstants>DEBUG</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugType>full</DebugType>
     <PlatformTarget>x86</PlatformTarget>
@@ -80,7 +80,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\x64\Debug\</OutputPath>
-    <DefineConstants>_WINDOWS</DefineConstants>
+    <DefineConstants>DEBUG;_WINDOWS,_X64</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugType>full</DebugType>
     <PlatformTarget>x64</PlatformTarget>
@@ -91,7 +91,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>
-    <DefineConstants>TRACE;WINDOWS</DefineConstants>
+    <DefineConstants>_WINDOWS;_X64</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
@@ -104,7 +104,31 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'DebugLinux|x64'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\x64\DebugLinux\</OutputPath>
-    <DefineConstants>DEBUG;</DefineConstants>
+    <DefineConstants>DEBUG;_X64</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <LangVersion>7.2</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'DebugWindows|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\DebugWindows\</OutputPath>
+    <DefineConstants>DEBUG;_WINDOWS</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <LangVersion>7.2</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'DebugWindows|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\DebugWindows\</OutputPath>
+    <DefineConstants>DEBUG;_WINDOWS;_X64</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugType>full</DebugType>
     <PlatformTarget>x64</PlatformTarget>
@@ -129,7 +153,6 @@
     <Compile Include="LZSS.cs" />
     <Compile Include="MakiExtended.cs" />
     <Compile Include="Memory.cs" />
-    <Compile Include="MemoryReader.cs" />
     <Compile Include="ModuleHandler.cs" />
     <Compile Include="module_battle.cs" />
     <Compile Include="module_battle_Debug.cs" />

--- a/FF8/init_debugger_Audio.cs
+++ b/FF8/init_debugger_Audio.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using System.IO;
-#if _WINDOWS
+#if _WINDOWS && !_X64
 using DirectMidi;
 #endif
 using System.Runtime.InteropServices;
@@ -18,7 +18,7 @@ namespace FF8
 #pragma warning restore IDE1006 // Naming Styles
     {
 
-#if _WINDOWS
+#if _WINDOWS && !_X64
         private static CDirectMusic cdm;
         private static CDLSLoader loader;
         private static CSegment segment;
@@ -473,7 +473,7 @@ namespace FF8
 
                     if (!MakiExtended.IsLinux)
                     {
-#if _WINDOWS                        
+#if _WINDOWS && !_X64                        
                         if (cdm == null)
                         {
                             cdm = new CDirectMusic();
@@ -564,7 +564,7 @@ namespace FF8
 
                 if (MakiExtended.IsLinux)
                 {
-#if _WINDOWS
+#if _WINDOWS && !_X64
                     cport.StopAll();
                     cport.Dispose();
                     ccollection.Dispose();
@@ -590,7 +590,7 @@ namespace FF8
                 ffccMusic = null;
             }
 
-#if _WINDOWS
+#if _WINDOWS && !_X64
             try
             {
                 if (!MakiExtended.IsLinux)


### PR DESCRIPTION
I added _X64  for any code that requires 64 bit. So we can use !_X64 for anything that doesn't work on 64 bit.

For some reason DEBUG compiler flag won't work with Debug. So I copied the DebugLinux and to Debugwindows set the _WINDOWS flag on it. I was just using that and setting _WINDOWS when I wasn't compiling on Linux.

Atleast for me the DEBUG checkbox would keep getting auto unchecked and the code would stay grayed out.

I was thinking of deleting the normal Debug but I'm unsure if we need it for something.