### PR TITLE
Fixed Linux Video

### DIFF
--- a/FF8/module_movie_test.cs
+++ b/FF8/module_movie_test.cs
@@ -151,6 +151,10 @@ namespace FF8
 
             Ffccaudio = new Ffcc(Movies[Index], AVMediaType.AVMEDIA_TYPE_AUDIO, Ffcc.FfccMode.STATE_MACH); //Ffcc.FfccMode.PROCESS_ALL);
             Ffccvideo = new Ffcc(Movies[Index], AVMediaType.AVMEDIA_TYPE_VIDEO, Ffcc.FfccMode.STATE_MACH);
+#if !_WINDOWS
+            Ffcc Ffccvideo2 = new Ffcc(Movies[Index], AVMediaType.AVMEDIA_TYPE_VIDEO, Ffcc.FfccMode.PROCESS_ALL);
+            //testing for linux just exporting all the frames to see if i am getting any progress
+#endif
             FPS = Ffccvideo.FPS;
             if (FPS == 0)
             {

--- a/FF8/module_movie_test.cs
+++ b/FF8/module_movie_test.cs
@@ -149,12 +149,9 @@ namespace FF8
         private static void InitMovie()
         {
 
-            Ffccaudio = new Ffcc(Movies[Index], AVMediaType.AVMEDIA_TYPE_AUDIO, Ffcc.FfccMode.STATE_MACH); //Ffcc.FfccMode.PROCESS_ALL);
+            Ffccaudio = new Ffcc(Movies[Index], AVMediaType.AVMEDIA_TYPE_AUDIO, Ffcc.FfccMode.STATE_MACH);
             Ffccvideo = new Ffcc(Movies[Index], AVMediaType.AVMEDIA_TYPE_VIDEO, Ffcc.FfccMode.STATE_MACH);
-#if !_WINDOWS
-            Ffcc Ffccvideo2 = new Ffcc(Movies[Index], AVMediaType.AVMEDIA_TYPE_VIDEO, Ffcc.FfccMode.PROCESS_ALL);
-            //testing for linux just exporting all the frames to see if i am getting any progress
-#endif
+
             FPS = Ffccvideo.FPS;
             if (FPS == 0)
             {


### PR DESCRIPTION
Removed Bitmap from equation and things started working.
Unsure why but when we load the data into a bitmap in linux it does not work.

So I think video playback is 100% functional.