### PR TITLE
Windows Registry and Open AL fix

### DIFF
--- a/FF8.sln
+++ b/FF8.sln
@@ -5,6 +5,12 @@ VisualStudioVersion = 15.0.28307.136
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FF8", "FF8\FF8.csproj", "{E23A12F6-73DC-4933-903B-2DC0765ED19B}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{E7D18589-9CDA-4F6B-AB1B-A7FB7939C3D7}"
+	ProjectSection(SolutionItems) = preProject
+		.gitignore = .gitignore
+		README.md = README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64

--- a/FF8/FF8.csproj
+++ b/FF8/FF8.csproj
@@ -173,6 +173,10 @@
     <Compile Include="PseudoBufferedStream.cs" />
     <Compile Include="Sources\Environment\Game\Location\HardcodedGameLocationProvider.cs" />
     <Compile Include="Sources\Exceptions\ExceptionList.cs" />
+    <Compile Include="Sources\MonoGame\Hooks\IMonoGameHook.cs" />
+    <Compile Include="Sources\MonoGame\Hooks\MonoGameHooks.cs" />
+    <Compile Include="Sources\MonoGame\Hooks\OpenALWindowsHook.cs" />
+    <Compile Include="Sources\NetFramework\TypeExtensionMethods.cs" />
     <Compile Include="TEX.cs" />
     <Compile Include="TIM2.cs" />
     <Compile Include="debug_battleDat.cs" />

--- a/FF8/FF8.csproj
+++ b/FF8/FF8.csproj
@@ -139,6 +139,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ArchiveWorker.cs" />
+    <Compile Include="Sources\Environment\Game\Location\GameLocation.cs" />
+    <Compile Include="Sources\Environment\Game\Location\IGameLocationProvider.cs" />
+    <Compile Include="Sources\Environment\Game\Location\LinuxGameLocationProvider.cs" />
+    <Compile Include="Sources\Environment\Game\Location\WindowsGameLocationProvider.cs" />
+    <Compile Include="Sources\Environment\Runtime\RuntimeEnvironment.cs" />
+    <Compile Include="Sources\Environment\Runtime\RuntimePlatform.cs" />
+    <Compile Include="Sources\Environment\Build\BuildEnvironment.cs" />
     <Compile Include="debug_MCH.cs" />
     <Compile Include="ExtapathyExtended.cs" />
     <Compile Include="Ffcc.cs" />
@@ -164,6 +171,8 @@
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PseudoBufferedStream.cs" />
+    <Compile Include="Sources\Environment\Game\Location\HardcodedGameLocationProvider.cs" />
+    <Compile Include="Sources\Exceptions\ExceptionList.cs" />
     <Compile Include="TEX.cs" />
     <Compile Include="TIM2.cs" />
     <Compile Include="debug_battleDat.cs" />
@@ -265,6 +274,7 @@
       <Install>false</Install>
     </BootstrapperPackage>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(MSBuildExtensionsPath)\MonoGame\v3.0\MonoGame.Content.Builder.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/FF8/FF8.csproj.DotSettings
+++ b/FF8/FF8.csproj.DotSettings
@@ -5,4 +5,5 @@
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=sources_005Cenvironment_005Cgame/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=sources_005Cenvironment_005Cgame_005Clocation/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=sources_005Cenvironment_005Cruntime/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=sources_005Cexceptions/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=sources_005Cexceptions/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=sources_005Cmonogame_005Chooks/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/FF8/FF8.csproj.DotSettings
+++ b/FF8/FF8.csproj.DotSettings
@@ -1,0 +1,8 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=sources/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=sources_005Cenvironment/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=sources_005Cenvironment_005Cbuild/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=sources_005Cenvironment_005Cgame/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=sources_005Cenvironment_005Cgame_005Clocation/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=sources_005Cenvironment_005Cruntime/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=sources_005Cexceptions/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/FF8/Memory.cs
+++ b/FF8/Memory.cs
@@ -100,7 +100,7 @@ namespace FF8
 
         public static int module = MODULE_OVERTURE_DEBUG;
         
-        public static string FF8DIR => GameLocation.Current.Path;
+        public static string FF8DIR => GameLocation.Current.DataPath;
 
         /// <summary>
         /// If true by the end of Update() will skip the next Draw()

--- a/FF8/Memory.cs
+++ b/FF8/Memory.cs
@@ -99,32 +99,9 @@ namespace FF8
 
 
         public static int module = MODULE_OVERTURE_DEBUG;
-        private static readonly string[] FF8DIR_list = {
-            @"C:\Program Files (x86)\Steam\steamapps\common\FINAL FANTASY VIII\Data\lang-en",
-            "/home/robert/FINAL_FANTASY_VIII/Data/lang-en",
-            @"D:\SteamLibrary\steamapps\common\FINAL FANTASY VIII\Data\lang-en",
-            @"D:\Steam\steamapps\common\FINAL FANTASY VIII\Data\lang-en",
-            "/media/griever/Data/SteamLibrary/steamapps/common/FINAL FANTASY VIII/Data/lang-en",
-            "/home/griever/.PlayOnLinux/wineprefix/Steam/drive_c/Program Files/Steam/steamapps/common/FINAL FANTASY VIII/Data/lang-en"
-        };
-        private static string gooddir = "";
-        public static string FF8DIR
-        {
-            get
-            {
-                if (gooddir == "")
-                {
-                    foreach (string s in FF8DIR_list)
-                    {
-                        if (Directory.Exists(s))
-                        {
-                            gooddir = s; break;
-                        }
-                    }
-                }
-                return gooddir;
-            }
-        }
+        
+        public static string FF8DIR => GameLocation.Current.Path;
+
         /// <summary>
         /// If true by the end of Update() will skip the next Draw()
         /// </summary>

--- a/FF8/Program.cs
+++ b/FF8/Program.cs
@@ -1,4 +1,13 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using FF8.MonoGame;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Audio;
+using MonoGame.OpenAL;
+using MonoGame.Utilities;
 
 namespace FF8
 {
@@ -13,6 +22,8 @@ namespace FF8
         [STAThread]
         static void Main()
         {
+            MonoGameHooks.Initialize();
+
             using (var game = new Game1())
                 game.Run();
         }

--- a/FF8/Sources/Environment/Build/BuildEnvironment.cs
+++ b/FF8/Sources/Environment/Build/BuildEnvironment.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace FF8
+{
+    public static class BuildEnvironment
+    {
+        public static Boolean IsWindows
+        {
+            get
+            {
+#if _WINDOWS
+                return true;
+#else
+                return fasle;
+#endif
+            }
+        }
+    }
+}

--- a/FF8/Sources/Environment/Game/Location/GameLocation.cs
+++ b/FF8/Sources/Environment/Game/Location/GameLocation.cs
@@ -1,0 +1,35 @@
+﻿using System;
+
+namespace FF8
+{
+    public sealed class GameLocation
+    {
+        public String Path { get; }
+
+        public GameLocation(String path)
+        {
+            Path = path;
+        }
+
+        public static GameLocation Current { get; } = GetCurrentLocation();
+
+        private static GameLocation GetCurrentLocation()
+        {
+            IGameLocationProvider provider = GetLocationProvider();
+            return provider.GetGameLocation();
+        }
+
+        private static IGameLocationProvider GetLocationProvider()
+        {
+            switch (RuntimeEnvironment.Platform)
+            {
+                case RuntimePlatform.Windows:
+                    return new WindowsGameLocationProvider();
+                case RuntimePlatform.Linux:
+                    return new LinuxGameLocationProvider();
+                default:
+                    throw new NotSupportedException(RuntimeEnvironment.Platform.ToString());
+            }
+        }
+    }
+}

--- a/FF8/Sources/Environment/Game/Location/GameLocation.cs
+++ b/FF8/Sources/Environment/Game/Location/GameLocation.cs
@@ -4,11 +4,11 @@ namespace FF8
 {
     public sealed class GameLocation
     {
-        public String Path { get; }
+        public String DataPath { get; }
 
-        public GameLocation(String path)
+        public GameLocation(String dataPath)
         {
-            Path = path;
+            DataPath = dataPath;
         }
 
         public static GameLocation Current { get; } = GetCurrentLocation();

--- a/FF8/Sources/Environment/Game/Location/HardcodedGameLocationProvider.cs
+++ b/FF8/Sources/Environment/Game/Location/HardcodedGameLocationProvider.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.IO;
+
+namespace FF8
+{
+    internal sealed class HardcodedGameLocationProvider
+    {
+        private readonly String[] _knownPaths;
+
+        public HardcodedGameLocationProvider(String[] knownPaths)
+        {
+            _knownPaths = knownPaths ?? throw new ArgumentNullException(nameof(knownPaths));
+        }
+
+        public Boolean FindGameLocation(out GameLocation gameLocation)
+        {
+            using (var errors = new ExceptionList())
+            {
+                foreach (var path in _knownPaths)
+                {
+                    try
+                    {
+                        if (!Directory.Exists(path))
+                            continue;
+
+                        gameLocation = new GameLocation(path);
+                        errors.Clear();
+                        return true;
+                    }
+                    catch (Exception ex)
+                    {
+                        errors.Add(ex);
+                    }
+                }
+            }
+
+            gameLocation = null;
+            return false;
+        }
+    }
+}

--- a/FF8/Sources/Environment/Game/Location/IGameLocationProvider.cs
+++ b/FF8/Sources/Environment/Game/Location/IGameLocationProvider.cs
@@ -1,0 +1,7 @@
+﻿namespace FF8
+{
+    public interface IGameLocationProvider
+    {
+        GameLocation GetGameLocation();
+    }
+}

--- a/FF8/Sources/Environment/Game/Location/LinuxGameLocationProvider.cs
+++ b/FF8/Sources/Environment/Game/Location/LinuxGameLocationProvider.cs
@@ -1,0 +1,23 @@
+﻿using System.IO;
+
+namespace FF8
+{
+    public sealed class LinuxGameLocationProvider : IGameLocationProvider
+    {
+        public GameLocation GetGameLocation()
+        {
+            if (_hardcoded.FindGameLocation(out var gameLocation))
+                return gameLocation;
+
+            throw new DirectoryNotFoundException($"Cannot find game directory." +
+                                                 $"Add your own path to the {nameof(LinuxGameLocationProvider)} type.");
+        }
+
+        private readonly HardcodedGameLocationProvider _hardcoded = new HardcodedGameLocationProvider(new[]
+        {
+            "/home/robert/FINAL_FANTASY_VIII/Data/lang-en",
+            "/media/griever/Data/SteamLibrary/steamapps/common/FINAL FANTASY VIII/Data/lang-en",
+            "/home/griever/.PlayOnLinux/wineprefix/Steam/drive_c/Program Files/Steam/steamapps/common/FINAL FANTASY VIII/Data/lang-en"
+        });
+    }
+}

--- a/FF8/Sources/Environment/Game/Location/WindowsGameLocationProvider.cs
+++ b/FF8/Sources/Environment/Game/Location/WindowsGameLocationProvider.cs
@@ -22,7 +22,7 @@ namespace FF8
                     String installLocation = (String)registryKey.GetValue(SteamGamePathTag);
                     String dataPath = Path.Combine(installLocation, "Data", "lang-en");
                     if (Directory.Exists(dataPath))
-                        return new GameLocation(installLocation);
+                        return new GameLocation(dataPath);
                 }
             }
 

--- a/FF8/Sources/Environment/Game/Location/WindowsGameLocationProvider.cs
+++ b/FF8/Sources/Environment/Game/Location/WindowsGameLocationProvider.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.IO;
+using Microsoft.Win32;
+
+namespace FF8
+{
+    public sealed class WindowsGameLocationProvider : IGameLocationProvider
+    {
+        private const String SteamRegistyPath = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Steam App 39150";
+        private const String SteamGamePathTag = @"InstallLocation";
+
+        public GameLocation GetGameLocation()
+        {
+            if (_hardcoded.FindGameLocation(out var gameLocation))
+                return gameLocation;
+
+            using (RegistryKey localMachine = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32))
+            using (RegistryKey registryKey = localMachine.OpenSubKey(SteamRegistyPath))
+            {
+                if (registryKey != null)
+                {
+                    String installLocation = (String)registryKey.GetValue(SteamGamePathTag);
+                    String dataPath = Path.Combine(installLocation, "Data", "lang-en");
+                    if (Directory.Exists(dataPath))
+                        return new GameLocation(installLocation);
+                }
+            }
+
+            throw new DirectoryNotFoundException($"Cannot find game directory." +
+                                                 $"Add your own path to the {nameof(WindowsGameLocationProvider)} type or fix a registration in the registry:" +
+                                                 $"{SteamRegistyPath}.{SteamGamePathTag}");
+        }
+
+        private readonly HardcodedGameLocationProvider _hardcoded = new HardcodedGameLocationProvider(new[]
+        {
+            @"C:\Program Files (x86)\Steam\steamapps\common\FINAL FANTASY VIII\Data\lang-en",
+            @"D:\SteamLibrary\steamapps\common\FINAL FANTASY VIII\Data\lang-en",
+            @"D:\Steam\steamapps\common\FINAL FANTASY VIII\Data\lang-en",
+        });
+    }
+}

--- a/FF8/Sources/Environment/Runtime/RuntimeEnvironment.cs
+++ b/FF8/Sources/Environment/Runtime/RuntimeEnvironment.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+namespace FF8
+{
+    public static class RuntimeEnvironment
+    {
+        public static RuntimePlatform Platform
+        {
+            get
+            {
+                PlatformID platform = Environment.OSVersion.Platform;
+                switch (platform)
+                {
+                    case PlatformID.Win32S:
+                    case PlatformID.Win32Windows:
+                    case PlatformID.Win32NT:
+                    case PlatformID.WinCE:
+                        return RuntimePlatform.Windows;
+                    case PlatformID.Unix:
+                    case (PlatformID)128:
+                        return RuntimePlatform.Linux;
+                    default:
+                        throw new NotSupportedException($"Environment.OSVersion.Platform = {platform}");
+                }
+            }
+        }
+    }
+}

--- a/FF8/Sources/Environment/Runtime/RuntimeEnvironment.cs
+++ b/FF8/Sources/Environment/Runtime/RuntimeEnvironment.cs
@@ -1,28 +1,57 @@
 ﻿using System;
+using System.Runtime.InteropServices;
 
 namespace FF8
 {
     public static class RuntimeEnvironment
     {
-        public static RuntimePlatform Platform
+        public static RuntimePlatform Platform { get; } = Init();
+
+        private static RuntimePlatform Init()
         {
-            get
+            PlatformID platform = Environment.OSVersion.Platform;
+            switch (platform)
             {
-                PlatformID platform = Environment.OSVersion.Platform;
-                switch (platform)
-                {
-                    case PlatformID.Win32S:
-                    case PlatformID.Win32Windows:
-                    case PlatformID.Win32NT:
-                    case PlatformID.WinCE:
-                        return RuntimePlatform.Windows;
-                    case PlatformID.Unix:
-                    case (PlatformID)128:
-                        return RuntimePlatform.Linux;
-                    default:
-                        throw new NotSupportedException($"Environment.OSVersion.Platform = {platform}");
-                }
+                case PlatformID.Win32S:
+                case PlatformID.Win32Windows:
+                case PlatformID.Win32NT:
+                case PlatformID.WinCE:
+                    return RuntimePlatform.Windows;
+                case PlatformID.Unix:
+                    return GetUnixPlatform();
+                case PlatformID.MacOSX:
+                    return RuntimePlatform.MacOSX;
+                default:
+                    throw new NotSupportedException($"Environment.OSVersion.Platform = {platform}");
             }
         }
+
+        private static RuntimePlatform GetUnixPlatform()
+        {
+            IntPtr buffer = IntPtr.Zero;
+            try
+            {
+                buffer = Marshal.AllocHGlobal(8192);
+                if (uname(buffer) == 0)
+                {
+                    if (Marshal.PtrToStringAnsi(buffer) == "Darwin")
+                        return RuntimePlatform.MacOSX;
+                }
+            }
+            catch
+            {
+                // Nothing
+            }
+            finally
+            {
+                if (buffer != IntPtr.Zero)
+                    Marshal.FreeHGlobal(buffer);
+            }
+
+            return RuntimePlatform.Linux;
+        }
+
+        [DllImport("libc")]
+        private static extern Int32 uname(IntPtr buf);
     }
 }

--- a/FF8/Sources/Environment/Runtime/RuntimePlatform.cs
+++ b/FF8/Sources/Environment/Runtime/RuntimePlatform.cs
@@ -1,0 +1,8 @@
+﻿namespace FF8
+{
+    public enum RuntimePlatform
+    {
+        Windows = 1,
+        Linux = 2
+    }
+}

--- a/FF8/Sources/Environment/Runtime/RuntimePlatform.cs
+++ b/FF8/Sources/Environment/Runtime/RuntimePlatform.cs
@@ -3,6 +3,7 @@
     public enum RuntimePlatform
     {
         Windows = 1,
-        Linux = 2
+        Linux = 2,
+        MacOSX = 3
     }
 }

--- a/FF8/Sources/Exceptions/ExceptionList.cs
+++ b/FF8/Sources/Exceptions/ExceptionList.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.ExceptionServices;
+using System.Text;
+
+namespace FF8
+{
+    public sealed class ExceptionList : IDisposable
+    {
+        private readonly List<Exception> _exceptions = new List<Exception>();
+
+        public void Add(Exception ex)
+        {
+            _exceptions.Add(ex);
+        }
+
+        public void Clear()
+        {
+            _exceptions.Clear();
+        }
+
+        public void Dispose()
+        {
+            switch (_exceptions.Count)
+            {
+                case 0:
+                {
+                    return;
+                }
+                case 1:
+                {
+                    ExceptionDispatchInfo.Capture(_exceptions[0]).Throw();
+                    return;
+                }
+                default:
+                {
+                    StringBuilder sb = new StringBuilder();
+
+                    foreach (var ex in _exceptions)
+                        sb.AppendLine(ex.Message);
+
+                    throw new AggregateException(sb.ToString(), _exceptions);
+                }
+            }
+        }
+    }
+}

--- a/FF8/Sources/MonoGame/Hooks/IMonoGameHook.cs
+++ b/FF8/Sources/MonoGame/Hooks/IMonoGameHook.cs
@@ -1,0 +1,7 @@
+﻿namespace FF8.MonoGame
+{
+    internal interface IMonoGameHook
+    {
+        void Initialize();
+    }
+}

--- a/FF8/Sources/MonoGame/Hooks/MonoGameHooks.cs
+++ b/FF8/Sources/MonoGame/Hooks/MonoGameHooks.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+
+namespace FF8.MonoGame
+{
+    public static class MonoGameHooks
+    {
+        public static void Initialize()
+        {
+            foreach (IMonoGameHook hook in EnumerateHooks())
+                hook.Initialize();
+        }
+
+        private static IEnumerable<IMonoGameHook> EnumerateHooks()
+        {
+            if (RuntimeEnvironment.Platform == RuntimePlatform.Windows)
+            {
+                // bug fix: NoAudioHardwareException (0x80004005): OpenAL device could not be initialized - NullReferenceException
+                yield return new OpenALWindowsHook();
+            }
+        }
+    }
+}

--- a/FF8/Sources/MonoGame/Hooks/OpenALWindowsHook.cs
+++ b/FF8/Sources/MonoGame/Hooks/OpenALWindowsHook.cs
@@ -1,0 +1,150 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using FF8.NetFramework;
+using Microsoft.Xna.Framework;
+
+namespace FF8.MonoGame
+{
+    /*
+        This hook loads OpenAL (soft_oal.dll) from the specified location if it wasn't found by the native code.
+
+        Reproduction:
+            Try to build and run this project from the directory containing # (e.g. "C:\Git\C#\OpenVIII")
+
+        Cause:
+            Incorrectly determined DLL directory.
+            Method: MonoGame.OpenAL.AL.GetNativeLibrary (MonoGame.Framework.dll)
+            Line: string directoryName = Path.GetDirectoryName(new Uri(typeof (AL).Assembly.CodeBase).LocalPath);
+                Uri.OriginalString: file:///C:/Git/C#/OpenVIII/FF8/bin/x64/Debug/MonoGame.Framework.DLL
+                Uri.LocalPath: C:\\Git\\C
+                Uri.Fragment: #/OpenVIII/FF8/bin/x64/Debug/MonoGame.Framework.DLL
+                GetDirectoryName: C:\Git
+                Expected: C:\Git\C#\OpenVIII\FF8\bin\x64\Debug
+
+        Exception:       
+            Microsoft.Xna.Framework.Audio.NoAudioHardwareException (0x80004005): OpenAL device could not be initialized. ---> System.NullReferenceException:
+               at Microsoft.Xna.Framework.Audio.OpenALSoundController.OpenSoundController()
+               at Microsoft.Xna.Framework.Audio.OpenALSoundController.OpenSoundController()
+               at Microsoft.Xna.Framework.Audio.OpenALSoundController..ctor()
+               at Microsoft.Xna.Framework.Audio.OpenALSoundController.get_GetInstance()
+               at Microsoft.Xna.Framework.SdlGamePlatform..ctor(Game game)
+               at Microsoft.Xna.Framework.Game..ctor()
+               at FF8.Game1..ctor()
+               at FF8.Program.Main()
+     */
+    internal sealed class OpenALWindowsHook : IMonoGameHook
+    {
+        public void Initialize()
+        {
+            if (RuntimeEnvironment.Platform != RuntimePlatform.Windows)
+                return;
+
+            Assembly gameFrameworkDll = typeof(Game).Assembly;
+
+            Type openAL = gameFrameworkDll.RequireType("MonoGame.OpenAL.AL");
+
+            // Invoke static .ctor to avoid overwriting fields
+            RuntimeHelpers.RunClassConstructor(openAL.TypeHandle);
+
+            // Get loaded library
+            FieldInfo nativeLibraryField = openAL.RequireStaticField("NativeLibrary");
+            IntPtr nativeLibrary = (IntPtr)nativeLibraryField.GetValue(obj: /*static*/ null);
+
+            // Return if OpenAL initialized correctly
+            if (nativeLibrary != IntPtr.Zero)
+                return;
+
+            // Looking for OpenAL (soft_oal.dll)
+            nativeLibrary = RequireOpenAL();
+
+            // Overwrite NativeLibrary field
+            nativeLibraryField.SetValue(obj: /*static*/ null, value: nativeLibrary);
+
+            // Overwrite Function fields
+            foreach (var pair in FieldToFunctionMap)
+            {
+                String fieldName = pair.Key;
+                FieldInfo field = openAL.RequireStaticField(fieldName);
+
+                String functionName = pair.Value;
+                Object function = RequireFunction(nativeLibrary, functionName, field.FieldType);
+
+                field.SetValue(obj: /*static*/ null, value: function);
+            }
+        }
+
+        private static IntPtr RequireOpenAL()
+        {
+            String platform = Environment.Is64BitProcess ? "x64" : "x86";
+
+            String libraryPath = $"{platform}/soft_oal.dll";
+            if (!File.Exists(libraryPath))
+                throw new DllNotFoundException($"Cannot find OpenAL DLL: {libraryPath}");
+
+            IntPtr library = WinAPI.LoadLibraryW($"{platform}/soft_oal.dll");
+            if (library == IntPtr.Zero)
+                throw new Win32Exception();
+
+            return library;
+        }
+
+        public static Object RequireFunction(IntPtr library, String function, Type delegateType)
+        {
+            IntPtr ptr = WinAPI.GetProcAddress(library, function);
+            if (ptr == IntPtr.Zero)
+                throw new Win32Exception();
+
+            return Marshal.GetDelegateForFunctionPointer(ptr, delegateType);
+        }
+
+        private static class WinAPI
+        {
+            [DllImport("kernel32", CharSet = CharSet.Unicode, SetLastError = true)]
+            public static extern IntPtr LoadLibraryW(String lpszLib);
+
+            [DllImport("kernel32", CharSet = CharSet.Ansi /* GetProcAddress doesn't have an Unicode version. */, SetLastError = true)]
+            public static extern IntPtr GetProcAddress(IntPtr hModule, String procName);
+        }
+
+        // ReSharper disable StringLiteralTypo
+        private static readonly Dictionary<String, String> FieldToFunctionMap = new Dictionary<String, String>
+        {
+            {"Enable", "alEnable"},
+            {"alBufferData", "alBufferData"},
+            {"alDeleteBuffers", "alDeleteBuffers"},
+            {"Bufferi", "alBufferi"},
+            {"GetBufferi", "alGetBufferi"},
+            {"Bufferiv", "alBufferiv"},
+            {"alGenBuffers", "alGenBuffers"},
+            {"alGenSources", "alGenSources"},
+            {"GetError", "alGetError"},
+            {"alIsBuffer", "alIsBuffer"},
+            {"alSourcePause", "alSourcePause"},
+            {"alSourcePlay", "alSourcePlay"},
+            {"IsSource", "alIsSource"},
+            {"alDeleteSources", "alDeleteSources"},
+            {"SourceStop", "alSourceStop"},
+            {"alSourcei", "alSourcei"},
+            {"alSource3i", "alSource3i"},
+            {"alSourcef", "alSourcef"},
+            {"alSource3f", "alSource3f"},
+            {"GetSource", "alGetSourcei"},
+            {"GetListener", "alGetListener3f"},
+            {"DistanceModel", "alDistanceModel"},
+            {"DopplerFactor", "alDopplerFactor"},
+            {"alSourceQueueBuffers", "alSourceQueueBuffers"},
+            {"alSourceUnqueueBuffers", "alSourceUnqueueBuffers"},
+            {"alSourceUnqueueBuffers2", "alSourceUnqueueBuffers"},
+            {"alGetEnumValue", "alGetEnumValue"},
+            {"IsExtensionPresent", "alIsExtensionPresent"},
+            {"alGetProcAddress", "alGetProcAddress"},
+            {"alGetString", "alGetString"}
+        };
+        // ReSharper restore StringLiteralTypo
+    }
+}

--- a/FF8/Sources/NetFramework/TypeExtensionMethods.cs
+++ b/FF8/Sources/NetFramework/TypeExtensionMethods.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Reflection;
+
+namespace FF8.NetFramework
+{
+    public static class TypeExtensionMethods
+    {
+        public static Type RequireType(this Assembly assembly, String typeName)
+        {
+            return assembly.GetType(typeName, throwOnError: true, ignoreCase: false);
+        }
+
+        public static FieldInfo RequireStaticField(this Type type, String fieldName)
+        {
+            return type.GetField(fieldName, BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
+                   ?? throw new NullReferenceException($"Cannot find the static field [{fieldName}] of type [{type}].");
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -67,9 +67,13 @@ Requirements: MonoGame + Visual Studio
 
 4. Open solution FF8.sln
 
-5. Edit game path (so far you have to type it manually) at `Memory.cs:67`:
+5. Edit game path (so far you have to type it manually)
+	at `WindowsGameLocationProvider.cs:34`:
+	at `LinuxGameLocationProvider.cs:16`:
 
-`public const string FF8DIR = @"D:\SteamLibrary\steamapps\common\FINAL FANTASY VIII\Data\lang-en\";`
+`private readonly HardcodedGameLocationProvider _hardcoded = ...`
+
+`@"D:\SteamLibrary\steamapps\common\FINAL FANTASY VIII\Data\lang-en\";`
 
 6. That's all. You can proceed with compilation. 
 


### PR DESCRIPTION
1. Addeded IGameLocationProvider. Invoke GameLocation.Current.DataPath to get the game data path. WindowsGameLocationProvider can read the path from the Windows registry. LinuxGameLocationProvider contains only hardcoded paths.

2. Added OpenALWindowsHook. This hook loads OpenAL (soft_oal.dll) from the specified location if it wasn't found by the native code.

    /*
        This hook loads OpenAL (soft_oal.dll) from the specified location if it wasn't found by the native code.

        Reproduction:
            Try to build and run this project from the directory containing # (e.g. "C:\Git\C#\OpenVIII")

        Cause:
            Incorrectly determined DLL directory.
            Method: MonoGame.OpenAL.AL.GetNativeLibrary (MonoGame.Framework.dll)
            Line: string directoryName = Path.GetDirectoryName(new Uri(typeof (AL).Assembly.CodeBase).LocalPath);
                Uri.OriginalString: file:///C:/Git/C#/OpenVIII/FF8/bin/x64/Debug/MonoGame.Framework.DLL
                Uri.LocalPath: C:\\Git\\C
                Uri.Fragment: #/OpenVIII/FF8/bin/x64/Debug/MonoGame.Framework.DLL
                GetDirectoryName: C:\Git
                Expected: C:\Git\C#\OpenVIII\FF8\bin\x64\Debug

        Exception:       
            Microsoft.Xna.Framework.Audio.NoAudioHardwareException (0x80004005): OpenAL device could not be initialized. ---> System.NullReferenceException:
               at Microsoft.Xna.Framework.Audio.OpenALSoundController.OpenSoundController()
               at Microsoft.Xna.Framework.Audio.OpenALSoundController.OpenSoundController()
               at Microsoft.Xna.Framework.Audio.OpenALSoundController..ctor()
               at Microsoft.Xna.Framework.Audio.OpenALSoundController.get_GetInstance()
               at Microsoft.Xna.Framework.SdlGamePlatform..ctor(Game game)
               at Microsoft.Xna.Framework.Game..ctor()
               at FF8.Game1..ctor()
               at FF8.Program.Main()
     */