### PR TITLE
Fixed reading gamepath from registry

### DIFF
--- a/Core/Sources/Environment/Game/Location/WindowsGameLocationProvider.cs
+++ b/Core/Sources/Environment/Game/Location/WindowsGameLocationProvider.cs
@@ -19,24 +19,31 @@ namespace OpenVIII
             if (_hardcoded.FindGameLocation(out var gameLocation))
                 return gameLocation;
 
-            using (RegistryKey localMachine = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32))
-            using (RegistryKey registryKey = localMachine.OpenSubKey(SteamRegistyPath))
+            foreach (RegistryView registryView in new RegistryView[] { RegistryView.Registry32, RegistryView.Registry64 })
             {
-                if (registryKey != null)
+                using (RegistryKey localMachine = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, registryView))
+                using (RegistryKey registryKey = localMachine.OpenSubKey(SteamRegistyPath))
                 {
-                    String installLocation = (String)registryKey.GetValue(SteamGamePathTag);
-                    String dataPath = installLocation;//Path.Combine(installLocation, "Data", "lang-en");
-                    if (Directory.Exists(dataPath))
-                        return new GameLocation(dataPath);
+                    if (registryKey != null)
+                    {
+                        String installLocation = (String)registryKey.GetValue(SteamGamePathTag);
+                        String dataPath = installLocation;//Path.Combine(installLocation, "Data", "lang-en");
+                        if (Directory.Exists(dataPath))
+                            return new GameLocation(dataPath);
+                    }
                 }
-            }
-            using (RegistryKey localMachine = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32))
-            using (RegistryKey registryKey = localMachine.OpenSubKey(CD2000RegistyPath))
-            {
-                String installLocation = (String)registryKey.GetValue(CD2000GamePathTag);
-                String dataPath = installLocation; //Path.Combine(installLocation, "Data"); //no lang-en on cd version.
-                if (Directory.Exists(dataPath))
-                    return new GameLocation(dataPath);
+                using (RegistryKey localMachine = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, registryView))
+                using (RegistryKey registryKey = localMachine.OpenSubKey(CD2000RegistyPath))
+                {
+                    if (registryKey != null)
+                    {
+                        String installLocation = (String)registryKey.GetValue(CD2000GamePathTag);
+                        String dataPath = installLocation; //Path.Combine(installLocation, "Data"); //no lang-en on cd version.
+                        if (Directory.Exists(dataPath))
+                            return new GameLocation(dataPath);
+                    }
+                }
+
             }
 
                 throw new DirectoryNotFoundException($"Cannot find game directory." +


### PR DESCRIPTION
Just downloaded the game from Steam using latest client version on Windows 10 (Preview 18922, not sure that created the issue). Anyways, for me the key is under the 64bit registry view.

I fixed it by iterating over both 32 and 64bit, in that order. I also did it for either version (Steam, CD version), whereas I'm pretty sure, CD version might be 32bit only. Feel free to fix it accordingly ;-)

I also fixed a potential NullPointer in the CD version reg reading, if the key does not exists.