### PR TITLE
Removed Character and VisibleCharacter from Menu_Base replaced with Damageable

### DIFF
--- a/Core/Battle/Enemy.cs
+++ b/Core/Battle/Enemy.cs
@@ -465,6 +465,8 @@ namespace OpenVIII
             return 0;
         }
 
+        public override Damageable Clone() => throw new NotImplementedException();
+
         public static implicit operator Module_battle_debug.EnemyInstanceInformation(Enemy @in) => @in.EII;
     }
 }

--- a/Core/Battle/Menu/BattleMenu.cs
+++ b/Core/Battle/Menu/BattleMenu.cs
@@ -16,7 +16,7 @@ namespace OpenVIII
 
         #region Constructors
 
-        public BattleMenu(Characters character, Characters? Visiblecharacter = null) : base(character, Visiblecharacter)
+        public BattleMenu(Damageable damageable) : base(damageable)
         {
         }
 
@@ -75,8 +75,8 @@ namespace OpenVIII
         {
             NoInputOnUpdate = true;
             Size = new Vector2 { X = 880, Y = 636 };
-            Data.Add(SectionName.HP, new IGMData_HP(new Rectangle((int)(Size.X - 389), 507, 389, 126), Character, VisibleCharacter));
-            Data.Add(SectionName.Commands, new IGMData_Commands(new Rectangle(50, (int)(Size.Y - 204), 210, 192), Character, VisibleCharacter, true));
+            Data.Add(SectionName.HP, new IGMData_HP(new Rectangle((int)(Size.X - 389), 507, 389, 126), Damageable));
+            Data.Add(SectionName.Commands, new IGMData_Commands(new Rectangle(50, (int)(Size.Y - 204), 210, 192), Damageable, true));
             Data.Add(SectionName.Renzokeken, new IGMData_Renzokeken(new Rectangle(0, 500, (int)Size.X, 124)));
             Data.ForEach(x => x.Value.SetModeChangeEvent(ref ModeChangeHandler));
             SetMode(Mode.ATB_Charging);

--- a/Core/Battle/Menu/BattleMenus.cs
+++ b/Core/Battle/Menu/BattleMenus.cs
@@ -317,7 +317,7 @@ namespace OpenVIII
                 menus = new List<Menu>(count);
                 foreach (KeyValuePair<int, Characters> m in party)
                 {
-                    BattleMenu tmp = new BattleMenu(Memory.State.PartyData[m.Key], m.Value);
+                    BattleMenu tmp = new BattleMenu(Memory.State[Memory.State.PartyData[m.Key]]);
                     tmp.Hide();
                     menus.Add(tmp);
                 }

--- a/Core/Battle/Menu/IGMData/IGMDataItem_ATB_Gradient.cs
+++ b/Core/Battle/Menu/IGMData/IGMDataItem_ATB_Gradient.cs
@@ -53,12 +53,12 @@ namespace OpenVIII
 
         #endregion Properties
 
-        public override void Refresh(Characters character, Characters? Visiblecharacter = null)
+        public override void Refresh(Damageable damageable)
         {
-            base.Refresh(character, Visiblecharacter);
+            base.Refresh(damageable);
             if (First)
             {
-                ATBBarPos = Memory.State[Character].ATBBarStart();
+                ATBBarPos = Damageable.ATBBarStart();
                 First = false;
             }
             else
@@ -71,32 +71,32 @@ namespace OpenVIII
         {
             if (Enabled)
             {
-                if (!Done && Character != Characters.Blank)
+                if (!Done && Damageable != null)
                 {
                     double tms = Memory.gameTime.ElapsedGameTime.TotalMilliseconds;
-                    ATBBarIncrement = Memory.State[Character].BarIncrement(); // per 60fps
+                    ATBBarIncrement = Damageable.BarIncrement(); // per 60fps
                     ATBBarPos += (int)(ATBBarIncrement * tms / 60);
                     Percent = (float)ATBBarPos / Enemy.ATBBarSize;
                     X = Lerp(Restriction.X - Width, Restriction.X, Percent);
 
-                    if (Memory.State[Character].IsDead)
+                    if (Damageable.IsDead)
                     {
                         //Color = Faded_Color = Color.Red * .5f;
                         ATBBarPos = 0;
                     }
-                    else if (Memory.State[Character].IsPetrify)
+                    else if (Damageable.IsPetrify)
                     {
                         Color = Faded_Color = Color.Gray * .8f;
                     }
-                    else if ((Memory.State[Character].Statuses1 & Kernel_bin.Battle_Only_Statuses.Stop) != 0)
+                    else if ((Damageable.Statuses1 & Kernel_bin.Battle_Only_Statuses.Stop) != 0)
                     {
                         Color = Faded_Color = Color.DarkBlue * .8f;
                     }
-                    else if ((Memory.State[Character].Statuses1 & Kernel_bin.Battle_Only_Statuses.Slow) != 0)
+                    else if ((Damageable.Statuses1 & Kernel_bin.Battle_Only_Statuses.Slow) != 0)
                     {
                         Color = Faded_Color = Color.DarkCyan * .8f;
                     }
-                    else if ((Memory.State[Character].Statuses1 & Kernel_bin.Battle_Only_Statuses.Haste) != 0)
+                    else if ((Damageable.Statuses1 & Kernel_bin.Battle_Only_Statuses.Haste) != 0)
                     {
                         Color = Faded_Color = Color.Violet * .8f;
                     }

--- a/Core/Battle/Menu/IGMData/IGMData_HP.cs
+++ b/Core/Battle/Menu/IGMData/IGMData_HP.cs
@@ -21,7 +21,7 @@ namespace OpenVIII
 
             #region Constructors
 
-            public IGMData_HP(Rectangle pos, Characters character, Characters Visiblecharacter) : base(3, 4, new IGMDataItem_Empty(pos), 1, 3, character, Visiblecharacter)
+            public IGMData_HP(Rectangle pos, Damageable damageable) : base(3, 4, new IGMDataItem_Empty(pos), 1, 3, damageable)
             {
             }
 
@@ -31,11 +31,11 @@ namespace OpenVIII
 
             public override void Refresh()
             {
-                if (Memory.State?.Characters != null)
+                if (Memory.State?.Characters != null && Damageable != null && Damageable.GetCharacterData(out Saves.CharacterData _c))
                 {
                     List<KeyValuePair<int, Characters>> party = GetParty();
                     byte pos = GetCharPos(party);
-                    foreach (KeyValuePair<int, Characters> pm in party.Where(x => x.Value == VisibleCharacter))
+                    foreach (KeyValuePair<int, Characters> pm in party.Where(x => x.Value == _c.ID))
                     {
                         Saves.CharacterData c = Memory.State.Characters[Memory.State.PartyData[pm.Key]];
                         FF8String name = Memory.Strings.GetName(pm.Value);
@@ -72,7 +72,7 @@ namespace OpenVIII
                             ITEM[pos, 2] = new IGMDataItem_ATB_Gradient(atbbarpos);
                             ((IGMDataItem_ATB_Gradient)ITEM[pos, 2]).Color = Color.Orange * .8f;
                             ((IGMDataItem_ATB_Gradient)ITEM[pos, 2]).Faded_Color = Color.Orange * .8f;
-                            ((IGMDataItem_ATB_Gradient)ITEM[pos, 2]).Refresh(Character, VisibleCharacter);
+                            ((IGMDataItem_ATB_Gradient)ITEM[pos, 2]).Refresh(Damageable);
                         }
 
                         // TODO: make a font render that can draw right to left from a point. For Right aligning the names.
@@ -94,14 +94,14 @@ namespace OpenVIII
                     var hg = (IGMDataItem_ATB_Gradient)ITEM[pos, 2];
                     if (hg.Done)
                     {
-                        var cm = BattleMenus.GetBattleMenus().First(x => x.VisibleCharacter == VisibleCharacter);
+                        var cm = BattleMenus.GetBattleMenus().First(x => x.Damageable == Damageable);
                         cm.SetMode(Mode.ATB_Charged);
                     }
                 }
                 return base.Update();
             }
 
-            private byte GetCharPos(List<KeyValuePair<int, Characters>> party) => (byte)party.FindIndex(x => x.Value == VisibleCharacter);
+            private byte GetCharPos(List<KeyValuePair<int, Characters>> party) => (byte)party.FindIndex(x => Damageable.GetCharacterData(out Saves.CharacterData c) && x.Value == c.ID);
             private static List<KeyValuePair<int, Characters>> GetParty() => Memory.State.Party.Select((element, index) => new { element, index }).ToDictionary(m => m.index, m => m.element).Where(m => !m.Value.Equals(Characters.Blank)).ToList();
 
             protected override void Init()

--- a/Core/Battle/Menu/IGMData/IGMData_PlayerEXP.cs
+++ b/Core/Battle/Menu/IGMData/IGMData_PlayerEXP.cs
@@ -37,16 +37,16 @@ namespace OpenVIII
                 {
                     get => _exp; set
                     {
-                        if (Character != Characters.Blank)
+                        if (Damageable != null)
                         {
-                            if (_exp == 0 || !Memory.State[Character].IsGameOver)
+                            if (_exp == 0 || !Damageable.IsGameOver)
                             {
                                 if (value < 0) value = 0;
-                                if (_exp != 0)
-                                    Memory.State[Character].Experience += (uint)Math.Abs((MathHelper.Distance(_exp, value)));
+                                if (_exp != 0 && Damageable.GetCharacterData(out Saves.CharacterData c))
+                                    c.Experience += (uint)Math.Abs((MathHelper.Distance(_exp, value)));
                                 _exp = value;
                             }
-                            else if (Memory.State[Character].IsGameOver)
+                            else if (Damageable.IsGameOver)
                                 ITEM[0, 11].Show();
                         }
                     }
@@ -60,12 +60,12 @@ namespace OpenVIII
 
                 public override bool Update()
                 {
-                    if (Character != Characters.Blank)
+                    if (Damageable != null && Damageable.GetCharacterData(out Saves.CharacterData c))
                     {
                         ((IGMDataItem_Int)ITEM[0, 4]).Data = _exp;
-                        ((IGMDataItem_Int)ITEM[0, 6]).Data = (int)Memory.State[Character].Experience;
-                        ((IGMDataItem_Int)ITEM[0, 8]).Data = Memory.State[Character].ExperienceToNextLevel;
-                        byte lvl = Memory.State[Character].Level;
+                        ((IGMDataItem_Int)ITEM[0, 6]).Data = checked((int)c.Experience);
+                        ((IGMDataItem_Int)ITEM[0, 8]).Data = c.ExperienceToNextLevel;
+                        byte lvl = Damageable.Level;
                         if (lvl != _lvl)
                         {
                             _lvl = lvl;
@@ -82,7 +82,7 @@ namespace OpenVIII
 
                 protected override void Init()
                 {
-                    if (Character != Characters.Blank)
+                    if (Damageable != null && Damageable.GetCharacterData(out Saves.CharacterData c))
                     {
 
                         Hide();
@@ -91,10 +91,10 @@ namespace OpenVIII
                                 Memory.Strings.Read(Strings.FileID.KERNEL, 30, 30) + "\n" +
                                 Memory.Strings.Read(Strings.FileID.KERNEL, 30, 31);
                         base.Init();
-                        uint exp = Memory.State[Character].Experience;
-                        ushort expTNL = Memory.State[Character].ExperienceToNextLevel;
-                        _lvl = Memory.State[Character].Level;
-                        FF8String name = Memory.Strings.GetName(VisibleCharacter);
+                        uint exp = c.Experience;
+                        ushort expTNL = c.ExperienceToNextLevel;
+                        _lvl = Damageable.Level;
+                        FF8String name = Damageable.Name;
 
                         ITEM[0, 0] = new IGMDataItem_String(name, new Rectangle(SIZE[0].X, SIZE[0].Y, 0, 0));
                         ITEM[0, 1] = new IGMDataItem_Icon(Icons.ID.Size_16x16_Lv_, new Rectangle(SIZE[0].X, SIZE[0].Y + 34, 0, 0), 13);

--- a/Core/Battle/Menu/IGMData/IGMData_PlayerEXPGroup.cs
+++ b/Core/Battle/Menu/IGMData/IGMData_PlayerEXPGroup.cs
@@ -136,10 +136,10 @@ namespace OpenVIII
                                 else
                                 {
                                     int total = 0;
-                                    foreach(var e in EXPExtra)
+                                    foreach (System.Collections.Generic.KeyValuePair<Characters, int> e in EXPExtra)
                                     {
                                         if (e.Value > 0)
-                                        total += (EXPExtra[e.Key] -= (int)remaining);
+                                            total += (EXPExtra[e.Key] -= (int)remaining);
                                         RefreshEXP();
                                     }
                                     if (total <= 0)
@@ -162,7 +162,7 @@ namespace OpenVIII
                 {
                     base.Init();
                     Cursor_Status |= (Cursor_Status.Hidden | (Cursor_Status.Enabled | Cursor_Status.Static));
-                    header = new IGMData_Container(new IGMDataItem_Box(Memory.Strings.Read(Strings.FileID.KERNEL, 30, 23), new Rectangle(0,0, CONTAINER.Width, 78), Icons.ID.INFO, Box_Options.Middle));
+                    header = new IGMData_Container(new IGMDataItem_Box(Memory.Strings.Read(Strings.FileID.KERNEL, 30, 23), new Rectangle(0, 0, CONTAINER.Width, 78), Icons.ID.INFO, Box_Options.Middle));
                 }
 
                 private void RefreshEXP()
@@ -170,13 +170,8 @@ namespace OpenVIII
                     foreach (Menu_Base i in ITEM)
                     {
                         int tmpexp = EXP;
-                        if (EXPExtra != null)
-                        {
-                            if (EXPExtra.TryGetValue(i.Character, out int bonus))
-                                tmpexp += bonus;
-                            else if (EXPExtra.TryGetValue(i.VisibleCharacter, out int bonus2))
-                                tmpexp += bonus2;
-                        }
+                        if (EXPExtra != null && i.Damageable.GetCharacterData(out Saves.CharacterData c) && EXPExtra.TryGetValue(c.ID, out int bonus))
+                            tmpexp += bonus;
                         ((IGMData_PlayerEXP)i).EXP = tmpexp;
                     }
                     header.CONTAINER.Width = CONTAINER.Width;

--- a/Core/Battle/Menu/IGMData/IGMData_Renzokeken.cs
+++ b/Core/Battle/Menu/IGMData/IGMData_Renzokeken.cs
@@ -121,7 +121,7 @@ namespace OpenVIII
 
         #region Constructors
 
-        public IGMData_Renzokeken(Rectangle? pos = null) : base(15, 1, new IGMDataItem_Box(pos: pos ?? new Rectangle(24, 501, 912, 123), title: Icons.ID.SPECIAL), 0, 0, Characters.Squall_Leonhart)
+        public IGMData_Renzokeken(Rectangle? pos = null) : base(15, 1, new IGMDataItem_Box(pos: pos ?? new Rectangle(24, 501, 912, 123), title: Icons.ID.SPECIAL), 0, 0, Memory.State?[Characters.Squall_Leonhart])
         {
         }
 

--- a/Core/Battle/Menu/IGMData/IGMData_TargetGroup.cs
+++ b/Core/Battle/Menu/IGMData/IGMData_TargetGroup.cs
@@ -513,9 +513,9 @@ namespace OpenVIII
 
             #region Constructors
 
-            public IGMData_TargetGroup(Characters character, Characters? Visiblecharacter = null, bool makesubs = true)
+            public IGMData_TargetGroup(Damageable damageable, bool makesubs = true)
             {
-                VisibleCharacter = Visiblecharacter ?? character;
+                
                 const int X = 25;
                 const int w = 380;
                 const int w2 = 210;
@@ -525,7 +525,7 @@ namespace OpenVIII
                 Init(new IGMData[]{
                     new IGMData_TargetEnemies(new Rectangle(CONTAINER.Pos.X, CONTAINER.Pos.Y, w, h)),
                     new IGMData_TargetParty(new Rectangle(CONTAINER.Pos.X + w, CONTAINER.Pos.Y, w2, h)),
-                    makesubs ? new IGMData_Draw_Pool(new Rectangle(X +50, Y - 50, 300, 192), Character, VisibleCharacter, true): null,
+                    makesubs ? new IGMData_Draw_Pool(new Rectangle(X +50, Y - 50, 300, 192), Damageable, true): null,
                     //makesubs ? new IGMData_BlueMagic_Pool(new Rectangle(X +50, Y - 50, 300, 192), Character, VisibleCharacter, true): null
                 }, true);
                 after();
@@ -598,10 +598,10 @@ namespace OpenVIII
                     return CommandDefault();
             }
 
-            public override void Refresh(Characters character, Characters? Visiblecharacter = null)
+            public override void Refresh(Damageable damageable)
             {
-                base.Refresh(character, Visiblecharacter);
-                Draw_Pool?.Refresh(character, Visiblecharacter);
+                base.Refresh(damageable);
+                Draw_Pool?.Refresh(damageable);
             }
 
             public override void Reset()

--- a/Core/Battle/Menu/VictoryMenu.cs
+++ b/Core/Battle/Menu/VictoryMenu.cs
@@ -110,7 +110,7 @@ namespace OpenVIII
             /// <summary>
             /// if you use this you will get no exp, ap, or items, No character specifics for this menu.
             /// </summary>
-            public override void Refresh(Characters c, Characters vc, bool backup = false) { }
+            public override void Refresh(Damageable damageable, bool backup = false) { }
 
             public void Refresh(int exp, uint ap, ConcurrentDictionary<Characters,int> expextra, ConcurrentDictionary<byte, byte> items, ConcurrentDictionary<Cards.ID, byte> cards)
             {

--- a/Core/Battle/module_battle_Debug.cs
+++ b/Core/Battle/module_battle_Debug.cs
@@ -211,7 +211,7 @@ namespace OpenVIII
             {
                 var c = Memory.State?[cii.VisibleCharacter];
 
-                if (cii.animationSystem.animationId >= 0 && cii.animationSystem.animationId <=2)
+                if (c != null && cii.animationSystem.animationId >= 0 && cii.animationSystem.animationId <=2)
                 {
                     // this would probably interfeer with other animations. I am hoping the limits above will keep it good.
                     if (c.IsDead)
@@ -578,7 +578,7 @@ battleCamera.cam.Camera_Lookat_Z_s16[1] / V, step) + 0;
                 if (CharacterInstances != null)
                     foreach(var cii in CharacterInstances)
                     {
-                        if (!cii.animationSystem.bStopAnimation  && !Memory.State[cii.VisibleCharacter].IsPetrify)
+                        if (!cii.animationSystem.bStopAnimation  && (!Memory.State[cii.VisibleCharacter]?.IsPetrify ?? true))
                         cii.animationSystem.animationFrame++;
                     }
                     //for (int x = 0; x < CharacterInstances.Count; x++)

--- a/Core/Field/Framework/OrderedDictionary.cs
+++ b/Core/Field/Framework/OrderedDictionary.cs
@@ -23,6 +23,14 @@ namespace OpenVIII
 
         public OrderedDictionary(int capacity = 0) => _list = new List<KeyValuePair<TKey, TValue>>(capacity);
 
+        public OrderedDictionary(IDictionary<TKey, TValue> copy) : this(copy.Count)
+        {
+            foreach (KeyValuePair<TKey, TValue> pair in copy)
+            {
+                Add(new KeyValuePair<TKey, TValue>(pair.Key, pair.Value));
+            }
+        }
+
         #endregion Constructors
 
         #region Properties
@@ -63,7 +71,7 @@ namespace OpenVIII
             set
             {
                 int index = _list.FindIndex(kvp => kvp.Key.Equals(key));
-                if(index>=0)
+                if (index >= 0)
                     _list[index] = new KeyValuePair<TKey, TValue>(key, value);
                 else
                     throw new KeyNotFoundException($"{this}::Key:{key} - Not Found!");
@@ -72,14 +80,8 @@ namespace OpenVIII
 
         TValue IDictionary<TKey, TValue>.this[TKey key]
         {
-            get
-            {
-                return this[key];
-            }
-            set
-            {
-                this[key] = value;
-            }
+            get => this[key];
+            set => this[key] = value;
         }
 
         #endregion Indexers
@@ -158,6 +160,7 @@ namespace OpenVIII
             value = default;
             return false;
         }
+
         public Boolean TryGetIndexByKey(TKey key, out int value)
         {
             if (ContainsKey(key))
@@ -194,6 +197,8 @@ namespace OpenVIII
         }
 
         public bool TryGetValue(TKey key, out TValue value) => TryGetByKey(key, out value);
+
+        public OrderedDictionary<TKey, TValue> Clone() => new OrderedDictionary<TKey, TValue>(this);
 
         IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator() => _list.GetEnumerator();
 

--- a/Core/Menu/IGM/IGMData/IGMData_NonParty.cs
+++ b/Core/Menu/IGM/IGMData/IGMData_NonParty.cs
@@ -26,7 +26,7 @@ namespace OpenVIII
 
             #region Properties
 
-            public Tuple<Characters, Characters>[] Contents { get; private set; }
+            public Damageable[] Contents { get; private set; }
 
             #endregion Properties
 
@@ -51,7 +51,7 @@ namespace OpenVIII
                             if (!Memory.State.Party.Contains((Characters)i) && Memory.State.Characters[(Characters)i].Available)
                             {
                                 BLANKS[pos] = false;
-                                Refresh(pos++, (Characters)i);
+                                Refresh(pos++, Memory.State[(Characters)i]);
                             }
                         }
                     }
@@ -72,7 +72,7 @@ namespace OpenVIII
                 _red_pixel = new Texture2D(Memory.graphics.GraphicsDevice, 1, 1, false, SurfaceFormat.Color);
                 Color[] color = new Color[] { new Color(74.5f / 100, 12.5f / 100, 11.8f / 100, 100) };
                 _red_pixel.SetData(color, 0, _red_pixel.Width * _red_pixel.Height);
-                Contents = new Tuple<Characters, Characters>[Count];
+                Contents = new Damageable[Count];
                 base.Init();
             }
 
@@ -84,44 +84,45 @@ namespace OpenVIII
                 if (row >= 2) SIZE[i].Y -= 4;
             }
 
-            private void Refresh(sbyte pos, Characters character)
+            private void Refresh(sbyte pos, Damageable damageable)
             {
-                Contents[pos] = new Tuple<Characters, Characters>(character, character);
-                float yoff = 39;
-                Rectangle rbak = SIZE[pos];
-                Rectangle r = rbak;
-                Color color = new Color(74.5f / 100, 12.5f / 100, 11.8f / 100, .9f);
-                ITEM[pos, 0] = new IGMDataItem_String(Memory.Strings.GetName(character), rbak);
-                CURSOR[pos] = new Point(rbak.X, (int)(rbak.Y + (6 * TextScale.Y)));
+                    Contents[pos] = damageable;
+                    float yoff = 39;
+                    Rectangle rbak = SIZE[pos];
+                    Rectangle r = rbak;
+                    Color color = new Color(74.5f / 100, 12.5f / 100, 11.8f / 100, .9f);
+                    ITEM[pos, 0] = new IGMDataItem_String(damageable.Name, rbak);
+                    CURSOR[pos] = new Point(rbak.X, (int)(rbak.Y + (6 * TextScale.Y)));
 
-                r.Offset(7, yoff);
-                ITEM[pos, 1] = new IGMDataItem_Icon(Icons.ID.Lv, r, 13);
+                    r.Offset(7, yoff);
+                    ITEM[pos, 1] = new IGMDataItem_Icon(Icons.ID.Lv, r, 13);
 
-                r = rbak;
-                r.Offset((49), yoff);
-                ITEM[pos, 2] = new IGMDataItem_Int(Memory.State.Characters[character].Level, r, 2, 0, 1, 3);
+                    r = rbak;
+                    r.Offset((49), yoff);
+                    ITEM[pos, 2] = new IGMDataItem_Int(damageable.Level, r, 2, 0, 1, 3);
 
-                r = rbak;
-                r.Offset(126, yoff);
-                ITEM[pos, 3] = new IGMDataItem_Icon(Icons.ID.HP2, r, 13);
+                    r = rbak;
+                    r.Offset(126, yoff);
+                    ITEM[pos, 3] = new IGMDataItem_Icon(Icons.ID.HP2, r, 13);
 
-                r.Offset(0, 28);
-                r.Width = 118;
-                r.Height = 1;
-                ITEM[pos, 4] = new IGMDataItem_Texture(_red_pixel, r) { Color = Color.Black };
-                r.Width = (int)(r.Width * Memory.State.Characters[character].PercentFullHP());
-                ITEM[pos, 5] = new IGMDataItem_Texture(_red_pixel, r) { Color = color };
+                    r.Offset(0, 28);
+                    r.Width = 118;
+                    r.Height = 1;
+                    ITEM[pos, 4] = new IGMDataItem_Texture(_red_pixel, r) { Color = Color.Black };
+                    r.Width = (int)(r.Width * damageable.PercentFullHP());
+                    ITEM[pos, 5] = new IGMDataItem_Texture(_red_pixel, r) { Color = color };
 
-                r.Width = 118;
-                r.Offset(0, 2);
-                ITEM[pos, 6] = new IGMDataItem_Texture(_red_pixel, r) { Color = Color.Black };
-                r.Width = (int)(r.Width * Memory.State.Characters[character].PercentFullHP());
-                ITEM[pos, 7] = new IGMDataItem_Texture(_red_pixel, r) { Color = color };
-                //TODO red bar resizes based on current/max hp
+                    r.Width = 118;
+                    r.Offset(0, 2);
+                    ITEM[pos, 6] = new IGMDataItem_Texture(_red_pixel, r) { Color = Color.Black };
+                    r.Width = (int)(r.Width * damageable.PercentFullHP());
+                    ITEM[pos, 7] = new IGMDataItem_Texture(_red_pixel, r) { Color = color };
+                    //TODO red bar resizes based on current/max hp
 
-                r = rbak;
-                r.Offset((166), yoff);
-                ITEM[pos, 8] = new IGMDataItem_Int(Memory.State.Characters[character].CurrentHP(), r, 2, 0, 1, 4);
+                    r = rbak;
+                    r.Offset((166), yoff);
+                    ITEM[pos, 8] = new IGMDataItem_Int(damageable.CurrentHP(), r, 2, 0, 1, 4);
+                
             }
 
             #endregion Methods

--- a/Core/Menu/IGM/IGMData/IGMData_NonParty.cs
+++ b/Core/Menu/IGM/IGMData/IGMData_NonParty.cs
@@ -86,7 +86,9 @@ namespace OpenVIII
 
             private void Refresh(sbyte pos, Damageable damageable)
             {
-                    Contents[pos] = damageable;
+                Contents[pos] = damageable;
+                if (damageable != null)
+                {             
                     float yoff = 39;
                     Rectangle rbak = SIZE[pos];
                     Rectangle r = rbak;
@@ -122,7 +124,8 @@ namespace OpenVIII
                     r = rbak;
                     r.Offset((166), yoff);
                     ITEM[pos, 8] = new IGMDataItem_Int(damageable.CurrentHP(), r, 2, 0, 1, 4);
-                
+
+                }
             }
 
             #endregion Methods

--- a/Core/Menu/IGM/IGMData/IGMData_Party.cs
+++ b/Core/Menu/IGM/IGMData/IGMData_Party.cs
@@ -28,7 +28,7 @@ namespace OpenVIII
 
             #region Properties
 
-            public Tuple<Characters, Characters>[] Contents { get; private set; }
+            public Damageable[] Contents { get; private set; }
             protected IReadOnlyDictionary<Enum, FF8String> Strings
             {
                 get
@@ -69,7 +69,7 @@ namespace OpenVIII
                     {
                         bool ret = base.Update();
                         for (sbyte i = 0; Memory.State.PartyData != null && i < SIZE.Length; i++)
-                            ReInitCharacter(i, Memory.State.PartyData[i], Memory.State.Party[i]);
+                            ReInitCharacter(i, Memory.State[Memory.State.PartyData[i]]);
                     }
                     skipReInit = false;
                 }
@@ -77,7 +77,7 @@ namespace OpenVIII
 
             protected override void Init()
             {
-                Contents = new Tuple<Characters, Characters>[Count];
+                Contents = new Damageable[Count];
                 base.Init();
             }
 
@@ -87,16 +87,16 @@ namespace OpenVIII
                 SIZE[i].Height -= vSpace;
             }
 
-            private void ReInitCharacter(sbyte pos, Characters character, Characters VisibleCharacter)
+            private void ReInitCharacter(sbyte pos, Damageable damageable)
             {
                 if (SIZE != null)
                 {
-                    if (character != Characters.Blank)
+                    if (damageable != null)
                     {
-                        Contents[pos] = new Tuple<Characters, Characters>(character, VisibleCharacter);
+                        Contents[pos] = damageable;
                         float yoff = 6;
 
-                        ITEM[pos, 0] = new IGMDataItem_Box(Memory.Strings.GetName(VisibleCharacter), title: Icons.ID.STATUS);
+                        ITEM[pos, 0] = new IGMDataItem_Box(damageable.Name, title: Icons.ID.STATUS);
                         Tuple<Rectangle, Point, Rectangle> dims = DrawBox(SIZE[pos], ((IGMDataItem_Box)ITEM[pos, 0]).Data, options: Box_Options.SkipDraw);
                         Rectangle r = dims.Item3;
                         ((IGMDataItem_Box)ITEM[pos, 0]).Pos = dims.Item1;
@@ -108,7 +108,7 @@ namespace OpenVIII
 
                         r = dims.Item3;
                         r.Offset((229), yoff);
-                        ITEM[pos, 2] = new IGMDataItem_Int(Memory.State.Characters[character].Level, r, 2, 0, 1, 3);
+                        ITEM[pos, 2] = new IGMDataItem_Int(damageable.Level, r, 2, 0, 1, 3);
 
                         r = dims.Item3;
                         r.Offset(304, yoff);
@@ -116,7 +116,7 @@ namespace OpenVIII
 
                         r = dims.Item3;
                         r.Offset((354), yoff);
-                        ITEM[pos, 4] = new IGMDataItem_Int(Memory.State.Characters[character].CurrentHP(VisibleCharacter), r, 2, 0, 1, 4);
+                        ITEM[pos, 4] = new IGMDataItem_Int(damageable.CurrentHP(), r, 2, 0, 1, 4);
 
                         r = dims.Item3;
                         r.Offset(437, yoff);
@@ -125,9 +125,9 @@ namespace OpenVIII
                         r = dims.Item3;
 
                         r.Offset((459), yoff);
-                        ITEM[pos, 6] = new IGMDataItem_Int(Memory.State.Characters[character].MaxHP(VisibleCharacter), r, 2, 0, 1, 4);
+                        ITEM[pos, 6] = new IGMDataItem_Int(damageable.MaxHP(), r, 2, 0, 1, 4);
 
-                        if (Memory.State.TeamLaguna || Memory.State.SmallTeam)
+                        if ((Memory.State.TeamLaguna || Memory.State.SmallTeam) && Damageable.GetCharacterData(out Saves.CharacterData c))
                         {
                             BLANKS[pos] = false;
                             r = dims.Item3;
@@ -137,7 +137,7 @@ namespace OpenVIII
 
                             r = dims.Item3;
                             r.Offset((340), 42);
-                            ITEM[pos, 8] = new IGMDataItem_Int((int)Memory.State.Characters[character].Experience, r, 2, 0, 1, 9);
+                            ITEM[pos, 8] = new IGMDataItem_Int(checked((int)c.Experience), r, 2, 0, 1, 9);
 
                             r = dims.Item3;
                             r.Offset(520, 42);
@@ -145,7 +145,7 @@ namespace OpenVIII
 
                             r = dims.Item3;
                             r.Offset((340), 75);
-                            ITEM[pos, 10] = new IGMDataItem_Int(Memory.State.Characters[character].ExperienceToNextLevel, r, 2, 0, 1, 9);
+                            ITEM[pos, 10] = new IGMDataItem_Int(c.ExperienceToNextLevel, r, 2, 0, 1, 9);
 
                             r = dims.Item3;
                             r.Offset(520, 75);

--- a/Core/Menu/IGM/IGMData/IGMData_PartyGroup.cs
+++ b/Core/Menu/IGM/IGMData/IGMData_PartyGroup.cs
@@ -13,7 +13,7 @@ namespace OpenVIII
             #region Fields
 
             private Items Choice;
-            private Tuple<Characters, Characters>[] Contents;
+            private Damageable[] Contents;
             private bool eventSet = false;
 
             #endregion Fields
@@ -53,7 +53,7 @@ namespace OpenVIII
                 {
                     case Items.Junction:
                         Module_main_menu_debug.State = Module_main_menu_debug.MainMenuStates.IGM_Junction;
-                        IGM_Junction.Refresh(Contents[CURSOR_SELECT].Item1, Contents[CURSOR_SELECT].Item2,true);
+                        IGM_Junction.Refresh(Contents[CURSOR_SELECT],true);
                         return true;
                 }
                 return ret;
@@ -79,13 +79,13 @@ namespace OpenVIII
                     SIZE = new Rectangle[total_Count];
                     CURSOR = new Point[total_Count];
                     BLANKS = new bool[total_Count];
-                    Contents = new Tuple<Characters, Characters>[total_Count];
+                    Contents = new Damageable[total_Count];
                     int i = 0;
                     test(Party, ref i, Party.Contents);
                     test(Non_Party, ref i, Non_Party.Contents);
                 }
 
-                void test(IGMData t, ref int i, Tuple<Characters, Characters>[] contents)
+                void test(IGMData t, ref int i, Damageable[] contents)
                 {
                     int pos = 0;
                     for (; pos < t.Count && i < total_Count; i++)

--- a/Core/Menu/IGMData/IGMData.cs
+++ b/Core/Menu/IGMData/IGMData.cs
@@ -62,19 +62,17 @@ namespace OpenVIII
 
         protected int GetCursor_select() => _cursor_select;
 
-        protected void Init(Characters? character, Characters? Visiblecharacter, sbyte? partypos)
+        protected void Init(Damageable damageable, sbyte? partypos)
         {
             if (partypos != null)
             {
-                Character = Memory.State?.PartyData?[partypos.Value] ?? Characters.Blank;
-                VisibleCharacter = Memory.State?.Party?[partypos.Value] ?? Character;
+                Damageable = damageable;
                 PartyPos = partypos.Value;
             }
-            else
+            else if (damageable != null && damageable.GetCharacterData(out Saves.CharacterData c))
             {
-                Character = character ?? Characters.Blank;
-                VisibleCharacter = Visiblecharacter ?? Character;
-                PartyPos = (sbyte)(Memory.State?.PartyData?.FindIndex(x => x.Equals(Character)) ?? -1);
+                Damageable = damageable;
+                PartyPos = (sbyte)(Memory.State?.PartyData?.FindIndex(x => x.Equals(c.ID)) ?? -1);
             }
         }
 
@@ -175,12 +173,12 @@ namespace OpenVIII
             if (!skipdata)
             {
                 if (CONTAINER != null)
-                    CONTAINER.Refresh(Character, VisibleCharacter);
+                    CONTAINER.Refresh(Damageable);
                 if (ITEM != null)
                     for (int i = 0; i < Count; i++)
                         for (int d = 0; d < Depth; d++)
                         {
-                            ITEM[i, d]?.Refresh(Character, VisibleCharacter);
+                            ITEM[i, d]?.Refresh(Damageable);
                         }
             }
         }
@@ -205,9 +203,9 @@ namespace OpenVIII
         /// </summary>
         public Rectangle[] SIZE;
 
-        public IGMData(int count = 0, int depth = 0, IGMDataItem container = null, int? cols = null, int? rows = null, Characters? character = null, Characters? Visiblecharacter = null, sbyte? partypos = null)
+        public IGMData(int count = 0, int depth = 0, IGMDataItem container = null, int? cols = null, int? rows = null, Damageable damageable = null, sbyte? partypos = null)
         {
-            Init(character, Visiblecharacter, partypos);
+            Init(damageable, partypos);
             Init(count, depth, container, cols, rows);
         }
 

--- a/Core/Menu/IGMData/IGMData.cs
+++ b/Core/Menu/IGMData/IGMData.cs
@@ -68,6 +68,7 @@ namespace OpenVIII
             {
                 _damageable = damageable;
                 PartyPos = partypos.Value;
+                _damageable = Memory.State[Memory.State.PartyData[PartyPos]];
             }
             else if (damageable != null && damageable.GetCharacterData(out Saves.CharacterData c))
             {

--- a/Core/Menu/IGMData/IGMData.cs
+++ b/Core/Menu/IGMData/IGMData.cs
@@ -66,12 +66,12 @@ namespace OpenVIII
         {
             if (partypos != null)
             {
-                Damageable = damageable;
+                _damageable = damageable;
                 PartyPos = partypos.Value;
             }
             else if (damageable != null && damageable.GetCharacterData(out Saves.CharacterData c))
             {
-                Damageable = damageable;
+                _damageable = damageable;
                 PartyPos = (sbyte)(Memory.State?.PartyData?.FindIndex(x => x.Equals(c.ID)) ?? -1);
             }
         }

--- a/Core/Menu/IGMData/IGMData_BlueMagic_Pool.cs
+++ b/Core/Menu/IGMData/IGMData_BlueMagic_Pool.cs
@@ -29,7 +29,7 @@ namespace OpenVIII
             {
                 ITEM[i, 0] = new IGMDataItem_String(null, SIZE[i]);
             }
-            ITEM[Rows, 0] = new BattleMenus.IGMData_TargetGroup(Character, VisibleCharacter, false);
+            ITEM[Rows, 0] = new BattleMenus.IGMData_TargetGroup(Damageable, false);
             PointerZIndex = 0;
         }
 
@@ -67,7 +67,7 @@ namespace OpenVIII
 
         #region Constructors
 
-        public IGMData_BlueMagic_Pool(Rectangle pos, Characters character = Characters.Blank, Characters? Visiblecharacter = null, bool battle = false) : base(5, 1, new IGMDataItem_Box(pos: pos, title: Icons.ID.SPECIAL), 4, 4, character, Visiblecharacter)
+        public IGMData_BlueMagic_Pool(Rectangle pos, Damageable damageable, bool battle = false) : base(5, 1, new IGMDataItem_Box(pos: pos, title: Icons.ID.SPECIAL), 4, 4, damageable)
         {
         }
 

--- a/Core/Menu/IGMData/IGMData_Commands.cs
+++ b/Core/Menu/IGMData/IGMData_Commands.cs
@@ -50,6 +50,7 @@ namespace OpenVIII
             ITEM[Targets_Window, 0] = new BattleMenus.IGMData_TargetGroup(Damageable);
             commands = new Kernel_bin.Battle_Commands[Rows];
             PointerZIndex = Limit_Arrow;
+            nonbattleWidth = Width;
         }
 
         //public override void Reset()
@@ -307,8 +308,6 @@ namespace OpenVIII
                     }
                 }
                 const int crisiswidth = 294;
-                if (Width != crisiswidth)
-                    nonbattleWidth = Width;
                 if (Battle && CrisisLevel)
                 {
                     CONTAINER.Width = crisiswidth;

--- a/Core/Menu/IGMData/IGMData_Commands.cs
+++ b/Core/Menu/IGMData/IGMData_Commands.cs
@@ -288,7 +288,8 @@ namespace OpenVIII
                             continue;
                         }
 #if DEBUG
-                        commands[pos] = Kernel_bin.BattleCommands[Cidoff++];
+                        if(!Battle) commands[pos] = cmdval.BattleCommand;
+                        else commands[pos] = Kernel_bin.BattleCommands[Cidoff++];
 #else
                         commands[pos] = cmdval.BattleCommand;
 #endif

--- a/Core/Menu/IGMData/IGMData_Group.cs
+++ b/Core/Menu/IGMData/IGMData_Group.cs
@@ -60,7 +60,7 @@ namespace OpenVIII
         {
             if (!skipdata)
                 foreach (Menu_Base i in ITEM)
-                    i?.Refresh(Character, VisibleCharacter);
+                    i?.Refresh(Damageable);
         }
 
         public override void Show()

--- a/Core/Menu/IGMData/IGMData_ItemPool.cs
+++ b/Core/Menu/IGMData/IGMData_ItemPool.cs
@@ -40,7 +40,7 @@ namespace OpenVIII
                 ITEM[pos, 0] = new IGMDataItem_String(null, SIZE[pos]);
                 ITEM[pos, 1] = new IGMDataItem_Int(0, new Rectangle(SIZE[pos].X + SIZE[pos].Width - 60, SIZE[pos].Y, 0, 0), numtype: Icons.NumType.sysFntBig, spaces: 3);
             }
-            ITEM[Targets_Window, 0] = new BattleMenus.IGMData_TargetGroup(Character, VisibleCharacter);
+            ITEM[Targets_Window, 0] = new BattleMenus.IGMData_TargetGroup(Damageable);
             ITEM[Rows - 1, 2] = new IGMDataItem_Icon(Icons.ID.NUM_, new Rectangle(SIZE[Rows - 1].X + SIZE[Rows - 1].Width - 60, Y, 0, 0), scale: new Vector2(2.5f));
             PointerZIndex = Rows - 1;
         }

--- a/Core/Menu/IGMData/IGMData_ItemPool.cs
+++ b/Core/Menu/IGMData/IGMData_ItemPool.cs
@@ -17,7 +17,7 @@ namespace OpenVIII
 
         #region Properties
 
-        private int Targets_Window => Rows;
+        private int Targets_Window => Count-3;
 
         #endregion Properties
 
@@ -40,8 +40,7 @@ namespace OpenVIII
                 ITEM[pos, 0] = new IGMDataItem_String(null, SIZE[pos]);
                 ITEM[pos, 1] = new IGMDataItem_Int(0, new Rectangle(SIZE[pos].X + SIZE[pos].Width - 60, SIZE[pos].Y, 0, 0), numtype: Icons.NumType.sysFntBig, spaces: 3);
             }
-            ITEM[Targets_Window, 0] = new BattleMenus.IGMData_TargetGroup(Damageable);
-            ITEM[Rows - 1, 2] = new IGMDataItem_Icon(Icons.ID.NUM_, new Rectangle(SIZE[Rows - 1].X + SIZE[Rows - 1].Width - 60, Y, 0, 0), scale: new Vector2(2.5f));
+            ITEM[Count - 1, 2] = new IGMDataItem_Icon(Icons.ID.NUM_, new Rectangle(SIZE[Rows - 1].X + SIZE[Rows - 1].Width - 60, Y, 0, 0), scale: new Vector2(2.5f));
             PointerZIndex = Rows - 1;
         }
 
@@ -51,8 +50,11 @@ namespace OpenVIII
             //SIZE[i].Inflate(-18, -20);
             //SIZE[i].Y -= 5 * row;
             SIZE[i].Inflate(-22, -8);
-            SIZE[i].Offset(0, 12 + (-8 * row));
-            SIZE[i].Height = (int)(12 * TextScale.Y);
+            //SIZE[i].Offset(0, 12 + (-8 * row));
+            int v = (int)(12 * TextScale.Y);
+            SIZE[i].Height = v;
+            SIZE[i].Y = Y + 18 + row*((Height-16)/Rows);
+
         }
 
         protected override void ModeChangeEvent(object sender, Enum e)
@@ -111,12 +113,15 @@ namespace OpenVIII
 
         #region Constructors
 
-        public IGMData_ItemPool(Rectangle pos, bool battle, int count = 4) : base(count + 1, 3, new IGMDataItem_Box(pos: pos, title: Icons.ID.ITEM), count, 198 / count + 1) => Battle = battle;
-
-        public IGMData_ItemPool() : base(11, 3, new IGMDataItem_Box(pos: new Rectangle(5, 150, 415, 480), title: Icons.ID.ITEM), 11, 18)
+        public IGMData_ItemPool(Rectangle pos, bool battle, int count = 4) : base(count + 1, 3, new IGMDataItem_Box(pos: pos, title: Icons.ID.ITEM), count, 198 / count + 1)
         {
-            if (!Battle)
-                ITEM[Targets_Window, 0] = null;
+            Battle = battle;
+            if(battle)
+                ITEM[Targets_Window, 0] = new BattleMenus.IGMData_TargetGroup(Damageable);
+        }
+
+        public IGMData_ItemPool() : this(new Rectangle(5, 150, 415, 480), false, 13)
+        {
         }
 
         #endregion Constructors
@@ -128,6 +133,7 @@ namespace OpenVIII
 
         public override bool Inputs()
         {
+            
             bool ret = false;
             if (InputITEM(Targets_Window, 0, ref ret))
             {

--- a/Core/Menu/IGMData/IGMData_Mag_Pool.cs
+++ b/Core/Menu/IGMData/IGMData_Mag_Pool.cs
@@ -219,7 +219,7 @@ namespace OpenVIII
 
         public static EventHandler<IGM_Junction.Mode> SlotConfirmListener;
 
-        public static EventHandler<IGM_Junction.Mode> SlotReinitListener;
+        public static EventHandler<Damageable> SlotRefreshListener;
 
         public static EventHandler<IGM_Junction.Mode> SlotUndoListener;
 
@@ -339,7 +339,7 @@ namespace OpenVIII
                         skipundo = false;
                     }
                     Source.JunctionSpell(Stat, Contents[CURSOR_SELECT]);
-                    SlotReinitListener?.Invoke(this, (IGM_Junction.Mode)Menu.IGM_Junction.GetMode());
+                    SlotRefreshListener?.Invoke(this,Damageable);
                 }
             }
         }
@@ -409,7 +409,7 @@ namespace OpenVIII
                 {
                     SlotUndoListener?.Invoke(this, (IGM_Junction.Mode)Menu.IGM_Junction.GetMode());
                     SlotConfirmListener?.Invoke(this, (IGM_Junction.Mode)Menu.IGM_Junction.GetMode());
-                    SlotReinitListener?.Invoke(this, (IGM_Junction.Mode)Menu.IGM_Junction.GetMode());
+                    SlotRefreshListener?.Invoke(this, Damageable);
                     switch (SortMode)
                     {
                         case IGM_Junction.Mode.Mag_Pool_Stat:

--- a/Core/Menu/IGMData/IGMData_Mag_Pool.cs
+++ b/Core/Menu/IGMData/IGMData_Mag_Pool.cs
@@ -92,8 +92,8 @@ namespace OpenVIII
         private bool Undo()
         {
             SlotUndoListener?.Invoke(this, (IGM_Junction.Mode)(Menu.IGM_Junction.GetMode()));
-            if (Memory.State.Characters != null)
-                Source = Memory.State.Characters[Character];
+            if (Memory.State.Characters != null && Damageable.GetCharacterData(out Saves.CharacterData c))
+                Source = c;
             return true;
         }
 
@@ -114,18 +114,18 @@ namespace OpenVIII
             {
                 Cursor_Status &= ~Cursor_Status.Enabled;
             }
-            if (Memory.State.Characters != null && Character != Characters.Blank)
+            if (Memory.State.Characters != null && Damageable != null)
             {
                 Get_Sort_Stat();
                 Stat = stat ?? Stat;
                 Get_Slots_Values();
-                if (SortMode != LastMode || this.Stat != LastStat || Character != LastCharacter)
+                if (SortMode != LastMode || this.Stat != LastStat || Damageable != LastCharacter)
                     Get_Sort();
                 bool skipundo = false;
-                if (Battle || !(SortMode == LastMode && Character == LastCharacter && this.Stat == LastStat && Page == LastPage))
+                if (Battle || !(SortMode == LastMode && Damageable == LastCharacter && this.Stat == LastStat && Page == LastPage))
                 {
                     // goal of these checks were to avoid updating the whole list if we don't need to.
-                    LastCharacter = Character;
+                    LastCharacter = Damageable;
                     LastStat = this.Stat;
                     LastPage = Page;
                     LastMode = SortMode;
@@ -158,7 +158,7 @@ namespace OpenVIII
             SIZE[Rows].Y = Y;
             ITEM[Rows, 2] = new IGMDataItem_Icon(Icons.ID.NUM_, new Rectangle(SIZE[Rows].X + SIZE[Rows].Width - 45, SIZE[Rows].Y, 0, 0), scale: new Vector2(2.5f));
 
-            ITEM[Targets_Window, 0] = new BattleMenus.IGMData_TargetGroup(Character, VisibleCharacter);
+            ITEM[Targets_Window, 0] = new BattleMenus.IGMData_TargetGroup(Damageable);
             BLANKS[Rows] = true;
             Cursor_Status &= ~Cursor_Status.Horizontal;
             Cursor_Status |= Cursor_Status.Vertical;
@@ -225,7 +225,7 @@ namespace OpenVIII
 
         public static EventHandler<Kernel_bin.Stat> StatEventListener;
 
-        public IGMData_Mag_Pool(Rectangle pos, Characters character = Characters.Blank, Characters? Visiblecharacter = null, bool battle = false) : base(5, 3, new IGMDataItem_Box(pos: pos, title: Icons.ID.MAGIC), 4, 13, character, Visiblecharacter)
+        public IGMData_Mag_Pool(Rectangle pos, Damageable damageable, bool battle = false) : base(5, 3, new IGMDataItem_Box(pos: pos, title: Icons.ID.MAGIC), 4, 13, damageable)
         {
             Battle = battle;
             skipReinit = true;
@@ -236,7 +236,7 @@ namespace OpenVIII
         {
         }
 
-        public Characters LastCharacter { get; private set; }
+        public Damageable LastCharacter { get; private set; }
 
         public IGM_Junction.Mode LastMode { get; private set; }
 
@@ -344,8 +344,11 @@ namespace OpenVIII
             }
         }
 
-        public void Get_Slots_Values() =>
-            Source = Memory.State.Characters[Character];
+        public void Get_Slots_Values()
+        {
+            if(Damageable.GetCharacterData(out Saves.CharacterData c))
+            Source = c;
+        }
 
         public void Get_Sort()
         {
@@ -431,7 +434,8 @@ namespace OpenVIII
                     }
 
                     Cursor_Status &= ~Cursor_Status.Enabled;
-                    Source = Memory.State.Characters[Character];
+                    if(Damageable.GetCharacterData(out Saves.CharacterData c))
+                        Source = c;
 
                     return true;
                 }

--- a/Core/Menu/IGMData/IGMData_Pool.cs
+++ b/Core/Menu/IGMData/IGMData_Pool.cs
@@ -4,7 +4,7 @@
     {
         #region Constructors
 
-        public IGMData_Pool(int count, int depth, IGMDataItem container = null, int? rows = null, int? pages = null, Characters character = Characters.Blank, Characters? Visiblecharacter = null) : base(count + 2, depth, container, 1, rows, character, Visiblecharacter) => DefaultPages = pages ?? 1;
+        public IGMData_Pool(int count, int depth, IGMDataItem container = null, int? rows = null, int? pages = null, Damageable damageable = null) : base(count + 2, depth, container, 1, rows, damageable) => DefaultPages = pages ?? 1;
 
         #endregion Constructors
 

--- a/Core/Menu/IGM_Junction/IGMData/IGMData_Abilities_AbilityPool.cs
+++ b/Core/Menu/IGM_Junction/IGMData/IGMData_Abilities_AbilityPool.cs
@@ -26,13 +26,13 @@ namespace OpenVIII
 
             public override bool Inputs_OKAY()
             {
-                if (Contents[CURSOR_SELECT] != Kernel_bin.Abilities.None && !BLANKS[CURSOR_SELECT])
+                if (Contents[CURSOR_SELECT] != Kernel_bin.Abilities.None && !BLANKS[CURSOR_SELECT] && Damageable.GetCharacterData(out Saves.CharacterData c))
                 {
                     skipsnd = true;
                     init_debugger_Audio.PlaySound(31);
                     base.Inputs_OKAY();
                     int target = IGM_Junction.Data[SectionName.TopMenu_Abilities].CURSOR_SELECT - 4;
-                    Memory.State.Characters[Character].Abilities[target] = Contents[CURSOR_SELECT];
+                    c.Abilities[target] = Contents[CURSOR_SELECT];
                     IGM_Junction.SetMode(Mode.Abilities);
                     IGM_Junction.Refresh(); // can be more specific if you want to find what is being changed.
                     return true;
@@ -48,14 +48,15 @@ namespace OpenVIII
                     Cursor_Status |= Cursor_Status.Enabled;
                 int pos = 0;
                 int skip = Page * Rows;
+                if(Damageable != null && Damageable.GetCharacterData(out Saves.CharacterData c))
                 for (int i = 0;
                     Memory.State.Characters != null &&
-                    i < Memory.State.Characters[Character].UnlockedGFAbilities.Count &&
+                    i < c.UnlockedGFAbilities.Count &&
                     pos < Rows; i++)
                 {
-                    if (Memory.State.Characters[Character].UnlockedGFAbilities[i] != Kernel_bin.Abilities.None)
+                    if (c.UnlockedGFAbilities[i] != Kernel_bin.Abilities.None)
                     {
-                        Kernel_bin.Abilities j = Memory.State.Characters[Character].UnlockedGFAbilities[i];
+                        Kernel_bin.Abilities j = c.UnlockedGFAbilities[i];
                         if (Source.ContainsKey(j))
                         {
                             if (skip > 0)
@@ -63,7 +64,7 @@ namespace OpenVIII
                                 skip--;
                                 continue;
                             }
-                            Font.ColorID cid = Memory.State.Characters[Character].Abilities.Contains(j) ? Font.ColorID.Grey : Font.ColorID.White;
+                            Font.ColorID cid = c.Abilities.Contains(j) ? Font.ColorID.Grey : Font.ColorID.White;
                             BLANKS[pos] = cid == Font.ColorID.Grey ? true : false;
 
                             ITEM[pos, 0] = new IGMDataItem_String(

--- a/Core/Menu/IGM_Junction/IGMData/IGMData_Abilities_AbilitySlots.cs
+++ b/Core/Menu/IGM_Junction/IGMData/IGMData_Abilities_AbilitySlots.cs
@@ -22,26 +22,26 @@ namespace OpenVIII
             {
                 base.Refresh();
 
-                if (Memory.State.Characters != null && Character != Characters.Blank)
+                if (Memory.State.Characters != null && Damageable != null && Damageable.GetCharacterData(out Saves.CharacterData c))
                 {
                     for (int i = 0; i < Count; i++)
                     {
                         int slots = 2;
-                        if (Memory.State.Characters[Character].UnlockedGFAbilities.Contains(Kernel_bin.Abilities.Abilityx3))
+                        if (c.UnlockedGFAbilities.Contains(Kernel_bin.Abilities.Abilityx3))
                             slots = 3;
-                        if (Memory.State.Characters[Character].UnlockedGFAbilities.Contains(Kernel_bin.Abilities.Abilityx4))
+                        if (c.UnlockedGFAbilities.Contains(Kernel_bin.Abilities.Abilityx4))
                             slots = 4;
                         if (i < slots)
                         {
                             ITEM[i, 0] = new IGMDataItem_Icon(Icons.ID.Arrow_Right2, SIZE[i], 9);
-                            if (Memory.State.Characters[Character].Abilities[i] != Kernel_bin.Abilities.None)
+                            if (c.Abilities[i] != Kernel_bin.Abilities.None)
                             {
                                 ITEM[i, 1] = new IGMDataItem_String(
 
-                                Kernel_bin.EquipableAbilities[Memory.State.Characters[Character].Abilities[i]].Icon, 9,
-                                Kernel_bin.EquipableAbilities[Memory.State.Characters[Character].Abilities[i]].Name,
+                                Kernel_bin.EquipableAbilities[c.Abilities[i]].Icon, 9,
+                                Kernel_bin.EquipableAbilities[c.Abilities[i]].Name,
                                 new Rectangle(SIZE[i].X + 40, SIZE[i].Y, 0, 0));
-                                Descriptions[i] = Kernel_bin.EquipableAbilities[Memory.State.Characters[Character].Abilities[i]].Description;
+                                Descriptions[i] = Kernel_bin.EquipableAbilities[c.Abilities[i]].Description;
                             }
                             else
                             {

--- a/Core/Menu/IGM_Junction/IGMData/IGMData_Abilities_CommandPool.cs
+++ b/Core/Menu/IGM_Junction/IGMData/IGMData_Abilities_CommandPool.cs
@@ -26,13 +26,13 @@ namespace OpenVIII
 
             public override bool Inputs_OKAY()
             {
-                if (Contents[CURSOR_SELECT] != Kernel_bin.Abilities.None && !BLANKS[CURSOR_SELECT])
+                if (Contents[CURSOR_SELECT] != Kernel_bin.Abilities.None && !BLANKS[CURSOR_SELECT] && Damageable.GetCharacterData(out Saves.CharacterData c))
                 {
                     skipsnd = true;
                     init_debugger_Audio.PlaySound(31);
                     base.Inputs_OKAY();
                     int target = IGM_Junction.Data[SectionName.TopMenu_Abilities].CURSOR_SELECT - 1;
-                    Memory.State.Characters[Character].Commands[target] = Contents[CURSOR_SELECT];
+                    c.Commands[target] = Contents[CURSOR_SELECT];
                     IGM_Junction.SetMode(Mode.Abilities);
                     IGM_Junction.Data[SectionName.TopMenu_Abilities].Refresh();
                     IGM_Junction.Data[SectionName.Commands].Refresh();
@@ -51,17 +51,18 @@ namespace OpenVIII
                 }
                 int pos = 0;
                 int skip = Page * Rows;
+                if(Damageable != null && Damageable.GetCharacterData(out Saves.CharacterData c))
                 for (int i = 0;
                     Memory.State.Characters != null &&
-                    i < Memory.State.Characters[Character].UnlockedGFAbilities.Count &&
+                    i < c.UnlockedGFAbilities.Count &&
                     pos < Rows; i++)
                 {
-                    if (Memory.State.Characters[Character].UnlockedGFAbilities[i] != Kernel_bin.Abilities.None)
+                    if (c.UnlockedGFAbilities[i] != Kernel_bin.Abilities.None)
                     {
-                        Kernel_bin.Abilities j = (Memory.State.Characters[Character].UnlockedGFAbilities[i]);
+                        Kernel_bin.Abilities j = (c.UnlockedGFAbilities[i]);
                         if (Source.ContainsKey(j) && skip-- <= 0)
                         {
-                            Font.ColorID cid = Memory.State.Characters[Character].Commands.Contains(j) ? Font.ColorID.Grey : Font.ColorID.White;
+                            Font.ColorID cid = c.Commands.Contains(j) ? Font.ColorID.Grey : Font.ColorID.White;
                             BLANKS[pos] = cid == Font.ColorID.Grey ? true : false;
                             ITEM[pos, 0] = new IGMDataItem_String(
                                 Icons.ID.Ability_Command, 9,

--- a/Core/Menu/IGM_Junction/IGMData/IGMData_Abilities_CommandSlots.cs
+++ b/Core/Menu/IGM_Junction/IGMData/IGMData_Abilities_CommandSlots.cs
@@ -31,7 +31,7 @@ namespace OpenVIII
                             ITEM[i, 1] = new IGMDataItem_String(
                                     Kernel_bin.BattleCommands[
                                         c.Abilities.Contains(Kernel_bin.Abilities.Mug) ?
-                                        13 :
+                                        12 :
                                         1].Name,
                                     new Rectangle(SIZE[i].X + 80, SIZE[i].Y, 0, 0));
                         }

--- a/Core/Menu/IGM_Junction/IGMData/IGMData_Abilities_CommandSlots.cs
+++ b/Core/Menu/IGM_Junction/IGMData/IGMData_Abilities_CommandSlots.cs
@@ -22,7 +22,7 @@ namespace OpenVIII
             {
                 base.Refresh();
 
-                if (Memory.State.Characters != null && Character != Characters.Blank)
+                if (Memory.State.Characters != null && Damageable != null && Damageable.GetCharacterData(out Saves.CharacterData c))
                 {
                     for (int i = 0; i < Count; i++)
                     {
@@ -30,7 +30,7 @@ namespace OpenVIII
                         {
                             ITEM[i, 1] = new IGMDataItem_String(
                                     Kernel_bin.BattleCommands[
-                                        Memory.State.Characters[Character].Abilities.Contains(Kernel_bin.Abilities.Mug) ?
+                                        c.Abilities.Contains(Kernel_bin.Abilities.Mug) ?
                                         13 :
                                         1].Name,
                                     new Rectangle(SIZE[i].X + 80, SIZE[i].Y, 0, 0));
@@ -38,11 +38,11 @@ namespace OpenVIII
                         else
                         {
                             ITEM[i, 0] = new IGMDataItem_Icon(Icons.ID.Arrow_Right2, SIZE[i], 9);
-                            ITEM[i, 1] = Memory.State.Characters[Character].Commands[i - 1] != Kernel_bin.Abilities.None ? new IGMDataItem_String(
+                            ITEM[i, 1] = c.Commands[i - 1] != Kernel_bin.Abilities.None ? new IGMDataItem_String(
                                 Icons.ID.Ability_Command, 9,
-                            Kernel_bin.Commandabilities[Memory.State.Characters[Character].Commands[i - 1]].Name,
+                            Kernel_bin.Commandabilities[c.Commands[i - 1]].Name,
                             new Rectangle(SIZE[i].X + 40, SIZE[i].Y, 0, 0)) : null;
-                            Kernel_bin.Abilities k = Memory.State.Characters[Character].Commands[i - 1];
+                            Kernel_bin.Abilities k = c.Commands[i - 1];
                             Descriptions[i] = k == Kernel_bin.Abilities.None ? null : Kernel_bin.Commandabilities[k].BattleCommand.Description;
                         }
                     }

--- a/Core/Menu/IGM_Junction/IGMData/IGMData_Abilities_Group.cs
+++ b/Core/Menu/IGM_Junction/IGMData/IGMData_Abilities_Group.cs
@@ -70,17 +70,17 @@ namespace OpenVIII
                 base.Inputs_Menu();
                 skipdata = false;
 
-                if (Commands!=null)
+                if (Commands!=null && Damageable.GetCharacterData(out Saves.CharacterData c))
                 {
                     if (CURSOR_SELECT < Commands.Count)
                     {
-                        Memory.State.Characters[Character].Commands[CURSOR_SELECT - 1] = Kernel_bin.Abilities.None;
+                        c.Commands[CURSOR_SELECT - 1] = Kernel_bin.Abilities.None;
                         IGM_Junction.Data[SectionName.TopMenu_Abilities].Refresh();
                         IGM_Junction.Data[SectionName.Commands].Refresh();
                     }
                     else
                     {
-                        Memory.State.Characters[Character].Abilities[CURSOR_SELECT - Commands.Count] = Kernel_bin.Abilities.None;
+                        c.Abilities[CURSOR_SELECT - Commands.Count] = Kernel_bin.Abilities.None;
                         IGM_Junction.Refresh();
                     }
                 }

--- a/Core/Menu/IGM_Junction/IGMData/IGMData_CharacterInfo.cs
+++ b/Core/Menu/IGM_Junction/IGMData/IGMData_CharacterInfo.cs
@@ -23,20 +23,22 @@ namespace OpenVIII
             /// </summary>
             public override void Refresh()
             {
-                base.Refresh();
-                ITEM[0, 0] = new IGMDataItem_Face((Faces.ID)VisibleCharacter, new Rectangle(X + 12, Y, 96, 144));
-                ITEM[0, 2] = new IGMDataItem_String(Memory.Strings.GetName(VisibleCharacter), new Rectangle(X + 117, Y + 0, 0, 0));
-
-                if (Memory.State.Characters != null)
+                if (Memory.State.Characters != null && Damageable.GetCharacterData(out Saves.CharacterData c))
                 {
-                    ITEM[0, 4] = new IGMDataItem_Int(Memory.State.Characters[Character].Level, new Rectangle(X + 117 + 35, Y + 54, 0, 0), 13, numtype: Icons.NumType.sysFntBig, padding: 1, spaces: 6);
-                    ITEM[0, 5] = Memory.State.Party != null && Memory.State.Party.Contains(Character)
+                    
+                base.Refresh();
+                ITEM[0, 0] = new IGMDataItem_Face((Faces.ID)c.ID, new Rectangle(X + 12, Y, 96, 144));
+                ITEM[0, 2] = new IGMDataItem_String(Damageable.Name, new Rectangle(X + 117, Y + 0, 0, 0));
+
+                
+                    ITEM[0, 4] = new IGMDataItem_Int(Damageable.Level, new Rectangle(X + 117 + 35, Y + 54, 0, 0), 13, numtype: Icons.NumType.sysFntBig, padding: 1, spaces: 6);
+                    ITEM[0, 5] = Memory.State.Party != null && Memory.State.Party.Contains(c.ID)
                         ? new IGMDataItem_Icon(Icons.ID.InParty, new Rectangle(X + 278, Y + 48, 0, 0), 6)
                         : null;
-                    ITEM[0, 7] = new IGMDataItem_Int(Memory.State.Characters[Character].CurrentHP(VisibleCharacter), new Rectangle(X + 152, Y + 108, 0, 0), 13, numtype: Icons.NumType.sysFntBig, padding: 1, spaces: 6);
-                    ITEM[0, 9] = new IGMDataItem_Int(Memory.State.Characters[Character].MaxHP(VisibleCharacter), new Rectangle(X + 292, Y + 108, 0, 0), 13, numtype: Icons.NumType.sysFntBig, padding: 1, spaces: 5);
-                    ITEM[0, 11] = new IGMDataItem_Int((int)Memory.State.Characters[Character].Experience, new Rectangle(X + 192, Y + 198, 0, 0), 13, numtype: Icons.NumType.Num_8x8_2, padding: 1, spaces: 9);
-                    ITEM[0, 13] = new IGMDataItem_Int(Memory.State.Characters[Character].ExperienceToNextLevel, new Rectangle(X + 192, Y + 231, 0, 0), 13, numtype: Icons.NumType.Num_8x8_2, padding: 1, spaces: 9);
+                    ITEM[0, 7] = new IGMDataItem_Int(Damageable.CurrentHP(), new Rectangle(X + 152, Y + 108, 0, 0), 13, numtype: Icons.NumType.sysFntBig, padding: 1, spaces: 6);
+                    ITEM[0, 9] = new IGMDataItem_Int(Damageable.MaxHP(), new Rectangle(X + 292, Y + 108, 0, 0), 13, numtype: Icons.NumType.sysFntBig, padding: 1, spaces: 5);
+                    ITEM[0, 11] = new IGMDataItem_Int((int)c.Experience, new Rectangle(X + 192, Y + 198, 0, 0), 13, numtype: Icons.NumType.Num_8x8_2, padding: 1, spaces: 9);
+                    ITEM[0, 13] = new IGMDataItem_Int(c.ExperienceToNextLevel, new Rectangle(X + 192, Y + 231, 0, 0), 13, numtype: Icons.NumType.Num_8x8_2, padding: 1, spaces: 9);
                 }
             }
 

--- a/Core/Menu/IGM_Junction/IGMData/IGMData_ConfirmRemAll.cs
+++ b/Core/Menu/IGM_Junction/IGMData/IGMData_ConfirmRemAll.cs
@@ -32,8 +32,8 @@ namespace OpenVIII
                         skipsnd = true;
                         init_debugger_Audio.PlaySound(31);
                         base.Inputs_OKAY();
-                        Memory.State.Characters[Character].RemoveAll();
-
+                        if(Damageable.GetCharacterData(out Saves.CharacterData c))
+                            c.RemoveAll();
                         IGM_Junction.Data[SectionName.RemAll].Hide();
                         IGM_Junction.Data[SectionName.TopMenu_Off].Hide();
                         IGM_Junction.SetMode(Mode.TopMenu);

--- a/Core/Menu/IGM_Junction/IGMData/IGMData_ConfirmRemMag.cs
+++ b/Core/Menu/IGM_Junction/IGMData/IGMData_ConfirmRemMag.cs
@@ -32,7 +32,8 @@ namespace OpenVIII
                         skipsnd = true;
                         init_debugger_Audio.PlaySound(31);
                         base.Inputs_OKAY();
-                        Memory.State.Characters[Character].RemoveMagic();
+                        if(Damageable.GetCharacterData(out Saves.CharacterData c))
+                            c.RemoveMagic();
                         Inputs_CANCEL();
                         IGM_Junction.Refresh();
                         break;

--- a/Core/Menu/IGM_Junction/IGMData/IGMData_GF_Junctioned.cs
+++ b/Core/Menu/IGM_Junction/IGMData/IGMData_GF_Junctioned.cs
@@ -50,7 +50,7 @@ namespace OpenVIII
             {
                 base.InitShift(i, col, row);
                 SIZE[i].Inflate(-45, -8);
-                SIZE[i].Offset((-10 * col), 0);
+                SIZE[i].Offset((-10 * col), -2*row);
             }
 
             #endregion Methods

--- a/Core/Menu/IGM_Junction/IGMData/IGMData_GF_Junctioned.cs
+++ b/Core/Menu/IGM_Junction/IGMData/IGMData_GF_Junctioned.cs
@@ -24,11 +24,11 @@ namespace OpenVIII
             public override void Refresh()
             {
                 base.Refresh();
-                if (Memory.State.Characters != null && Character != Characters.Blank)
+                if (Memory.State.Characters != null && Damageable != null && Damageable.GetCharacterData(out Saves.CharacterData c))
                 {
                     IEnumerable<Enum> availableFlags = Enum.GetValues(typeof(Saves.GFflags)).Cast<Enum>();
                     int pos = 0;
-                    foreach (Enum flag in availableFlags.Where(Memory.State.Characters[Character].JunctionnedGFs.HasFlag))
+                    foreach (Enum flag in availableFlags.Where(c.JunctionnedGFs.HasFlag))
                     {
                         if ((Saves.GFflags)flag == Saves.GFflags.None) continue;
                         ITEM[pos, 0] = new IGMDataItem_String(

--- a/Core/Menu/IGM_Junction/IGMData/IGMData_GF_Pool.cs
+++ b/Core/Menu/IGM_Junction/IGMData/IGMData_GF_Pool.cs
@@ -42,10 +42,10 @@ namespace OpenVIII
                 init_debugger_Audio.PlaySound(31);
                 base.Inputs_OKAY();
                 GFs select = Contents[CURSOR_SELECT];
-                Characters c = JunctionedGFs.ContainsKey(select) ? JunctionedGFs[select] : Character;
+                Characters c = Damageable.GetCharacterData(out Saves.CharacterData c1) && JunctionedGFs.ContainsKey(select) ? JunctionedGFs[select] : c1?.ID ?? Characters.Blank;
                 if (c != Characters.Blank)
                 {
-                    if (c != Character)
+                    if (c != c1.ID)
                     {
                         //show error msg
                     }
@@ -137,43 +137,45 @@ namespace OpenVIII
                 Source = Memory.State;
                 JunctionedGFs = Source.JunctionedGFs();
                 UnlockedGFs = Source.UnlockedGFs();
-
-                int pos = 0;
-                int skip = Page * Rows;
-                foreach (GFs g in UnlockedGFs.Where(g => !JunctionedGFs.ContainsKey(g)))
+                if (Damageable != null && Damageable.GetCharacterData(out Saves.CharacterData c))
                 {
-                    if (pos >= Rows) break;
-                    if (skip-- <= 0)
+                    int pos = 0;
+                    int skip = Page * Rows;
+                    foreach (GFs g in UnlockedGFs.Where(g => !JunctionedGFs.ContainsKey(g)))
                     {
-                        addGF(ref pos, g);
+                        if (pos >= Rows) break;
+                        if (skip-- <= 0)
+                        {
+                            addGF(ref pos, g);
+                        }
                     }
-                }
-                foreach (GFs g in UnlockedGFs.Where(g => JunctionedGFs.ContainsKey(g) && JunctionedGFs[g] == Character))
-                {
-                    if (pos >= Rows) break;
-                    if (skip-- <= 0)
+                    foreach (GFs g in UnlockedGFs.Where(g => JunctionedGFs.ContainsKey(g) && JunctionedGFs[g] == c.ID))
                     {
-                        addGF(ref pos, g, Font.ColorID.Grey);
+                        if (pos >= Rows) break;
+                        if (skip-- <= 0)
+                        {
+                            addGF(ref pos, g, Font.ColorID.Grey);
+                        }
                     }
-                }
-                foreach (GFs g in UnlockedGFs.Where(g => JunctionedGFs.ContainsKey(g) && JunctionedGFs[g] != Character))
-                {
-                    if (pos >= Rows) break;
-                    if (skip-- <= 0)
+                    foreach (GFs g in UnlockedGFs.Where(g => JunctionedGFs.ContainsKey(g) && JunctionedGFs[g] != c.ID))
                     {
-                        addGF(ref pos, g, Font.ColorID.Dark_Gray);
+                        if (pos >= Rows) break;
+                        if (skip-- <= 0)
+                        {
+                            addGF(ref pos, g, Font.ColorID.Dark_Gray);
+                        }
                     }
+                    for (; pos < Rows; pos++)
+                    {
+                        ITEM[pos, 0] = null;
+                        ITEM[pos, 1] = null;
+                        ITEM[pos, 2] = null;
+                        BLANKS[pos] = true;
+                    }
+                    base.Refresh();
+                    UpdateTitle();
+                    UpdateCharacter();
                 }
-                for (; pos < Rows; pos++)
-                {
-                    ITEM[pos, 0] = null;
-                    ITEM[pos, 1] = null;
-                    ITEM[pos, 2] = null;
-                    BLANKS[pos] = true;
-                }
-                base.Refresh();
-                UpdateTitle();
-                UpdateCharacter();
             }
 
             public override void UpdateTitle()

--- a/Core/Menu/IGM_Junction/IGMData/IGMData_Mag_EL_A_D_Slots.cs
+++ b/Core/Menu/IGM_Junction/IGMData/IGMData_Mag_EL_A_D_Slots.cs
@@ -24,7 +24,7 @@ namespace OpenVIII
 
             #region Methods
 
-            public override void BackupSetting() => SetPrevSetting(Memory.State.Characters[Character].Clone());
+            public override void BackupSetting() => SetPrevSetting((Saves.CharacterData)Damageable.Clone());
 
             public override void CheckMode(bool cursor = true) =>
                 CheckMode(0, Mode.Mag_EL_A, Mode.Mag_EL_D,
@@ -68,16 +68,16 @@ namespace OpenVIII
                 skipdata = true;
                 base.Inputs_Menu();
                 skipdata = false;
-                if (Contents[CURSOR_SELECT] == Kernel_bin.Stat.None)
+                if (Contents[CURSOR_SELECT] == Kernel_bin.Stat.None && Damageable.GetCharacterData(out Saves.CharacterData c))
                 {
-                    Memory.State.Characters[Character].Stat_J[Contents[CURSOR_SELECT]] = 0;
+                    c.Stat_J[Contents[CURSOR_SELECT]] = 0;
                     IGM_Junction.Refresh();
                 }
             }
 
             public override void Refresh()
             {
-                if (Memory.State.Characters != null && Character != Characters.Blank)
+                if (Memory.State.Characters != null && Damageable != null)
                 {
                     base.Refresh();
                     FillData(Icons.ID.Icon_Elemental_Attack, Kernel_bin.Stat.EL_Atk, Kernel_bin.Stat.EL_Def_1);
@@ -89,7 +89,7 @@ namespace OpenVIII
                 //override this use it to take value of prevSetting and restore the setting unless default method works
                 if (GetPrevSetting() != null)
                 {
-                    Memory.State.Characters[Character] = GetPrevSetting().Clone();
+                    Damageable = GetPrevSetting().Clone();
                 }
             }
 

--- a/Core/Menu/IGM_Junction/IGMData/IGMData_Mag_EL_A_D_Slots.cs
+++ b/Core/Menu/IGM_Junction/IGMData/IGMData_Mag_EL_A_D_Slots.cs
@@ -87,9 +87,10 @@ namespace OpenVIII
             public override void UndoChange()
             {
                 //override this use it to take value of prevSetting and restore the setting unless default method works
-                if (GetPrevSetting() != null)
+                if (GetPrevSetting() != null && Damageable.GetCharacterData(out Saves.CharacterData c))
                 {
-                    Damageable = GetPrevSetting().Clone();
+                    c.Magics = GetPrevSetting().CloneMagic();
+                    c.Stat_J = GetPrevSetting().CloneMagicJunction();
                 }
             }
 
@@ -98,7 +99,7 @@ namespace OpenVIII
                 if (!eventAdded)
                 {
                     IGMData_Mag_Pool.SlotConfirmListener += ConfirmChangeEvent;
-                    IGMData_Mag_Pool.SlotReinitListener += ReInitEvent;
+                    IGMData_Mag_Pool.SlotRefreshListener += ReInitEvent;
                     IGMData_Mag_Pool.SlotUndoListener += UndoChangeEvent;
                 }
                 base.AddEventListener();
@@ -151,7 +152,7 @@ namespace OpenVIII
 
             private void ConfirmChangeEvent(object sender, Mode e) => ConfirmChange();
 
-            private void ReInitEvent(object sender, Mode e) => Refresh();
+            private void ReInitEvent(object sender, Damageable e) => Refresh(e);
 
             private void UndoChangeEvent(object sender, Mode e) => UndoChange();
 

--- a/Core/Menu/IGM_Junction/IGMData/IGMData_Mag_EL_A_Values.cs
+++ b/Core/Menu/IGM_Junction/IGMData/IGMData_Mag_EL_A_Values.cs
@@ -25,10 +25,10 @@ namespace OpenVIII
 
             public override bool Update()
             {
-                if (Memory.State.Characters != null)
+                if (Memory.State.Characters != null && Damageable.GetCharacterData(out Saves.CharacterData c))
                 {
                     Dictionary<Kernel_bin.Element, byte> oldtotal = (prevSetting != null) ? getTotal(prevSetting, out Enum[] availableFlagsarray) : null;
-                    Dictionary<Kernel_bin.Element, byte> total = getTotal(Memory.State.Characters[Character], out availableFlagsarray);
+                    Dictionary<Kernel_bin.Element, byte> total = getTotal(c, out availableFlagsarray);
                     FillData(oldtotal, total, availableFlagsarray, Icons.ID.Element_Fire, palette: 9);
                 }
                 return base.Update();

--- a/Core/Menu/IGM_Junction/IGMData/IGMData_Mag_EL_D_Values.cs
+++ b/Core/Menu/IGM_Junction/IGMData/IGMData_Mag_EL_D_Values.cs
@@ -29,10 +29,10 @@ namespace OpenVIII
 
             public override bool Update()
             {
-                if (Memory.State.Characters != null)
+                if (Memory.State.Characters != null && Damageable.GetCharacterData(out Saves.CharacterData c))
                 {
                     Dictionary<Kernel_bin.Element, byte> oldtotal = (prevSetting != null) ? getTotal(prevSetting, out Enum[] availableFlagsarray) : null;
-                    Dictionary<Kernel_bin.Element, byte> total = getTotal(Memory.State.Characters[Character], out availableFlagsarray);
+                    Dictionary<Kernel_bin.Element, byte> total = getTotal(c, out availableFlagsarray);
                     FillData(oldtotal, total, availableFlagsarray, Icons.ID.Element_Fire, palette: 9);
                 }
                 return base.Update();

--- a/Core/Menu/IGM_Junction/IGMData/IGMData_Mag_ST_A_D_Slots.cs
+++ b/Core/Menu/IGM_Junction/IGMData/IGMData_Mag_ST_A_D_Slots.cs
@@ -81,9 +81,10 @@ namespace OpenVIII
             public override void UndoChange()
             {
                 //override this use it to take value of prevSetting and restore the setting unless default method works
-                if (GetPrevSetting() != null)
+                if (GetPrevSetting() != null && Damageable.GetCharacterData(out Saves.CharacterData c))
                 {
-                    Damageable = GetPrevSetting().Clone();
+                    c.Magics = GetPrevSetting().CloneMagic();
+                    c.Stat_J = GetPrevSetting().CloneMagicJunction();
                 }
             }
 
@@ -92,7 +93,7 @@ namespace OpenVIII
                 if (!eventAdded)
                 {
                     IGMData_Mag_Pool.SlotConfirmListener += ConfirmChangeEvent;
-                    IGMData_Mag_Pool.SlotReinitListener += ReInitEvent;
+                    IGMData_Mag_Pool.SlotRefreshListener += ReInitEvent;
                     IGMData_Mag_Pool.SlotUndoListener += UndoChangeEvent;
                 }
                 base.AddEventListener();
@@ -147,7 +148,7 @@ namespace OpenVIII
 
             private void ConfirmChangeEvent(object sender, Mode e) => ConfirmChange();
 
-            private void ReInitEvent(object sender, Mode e) => Refresh();
+            private void ReInitEvent(object sender, Damageable e) => Refresh(e);
 
             private void UndoChangeEvent(object sender, Mode e) => UndoChange();
 

--- a/Core/Menu/IGM_Junction/IGMData/IGMData_Mag_ST_A_D_Slots.cs
+++ b/Core/Menu/IGM_Junction/IGMData/IGMData_Mag_ST_A_D_Slots.cs
@@ -18,7 +18,7 @@ namespace OpenVIII
 
             #region Methods
 
-            public override void BackupSetting() => SetPrevSetting(Memory.State.Characters[Character].Clone());
+            public override void BackupSetting() => SetPrevSetting((Saves.CharacterData)Damageable.Clone());
 
             public override void CheckMode(bool cursor = true) =>
                 CheckMode(0, Mode.Mag_ST_A, Mode.Mag_ST_D,
@@ -62,16 +62,16 @@ namespace OpenVIII
                 skipdata = true;
                 base.Inputs_Menu();
                 skipdata = false;
-                if (Contents[CURSOR_SELECT] == Kernel_bin.Stat.None)
+                if (Contents[CURSOR_SELECT] == Kernel_bin.Stat.None && Damageable.GetCharacterData(out Saves.CharacterData c))
                 {
-                    Memory.State.Characters[Character].Stat_J[Contents[CURSOR_SELECT]] = 0;
+                    c.Stat_J[Contents[CURSOR_SELECT]] = 0;
                     IGM_Junction.Refresh();
                 }
             }
 
             public override void Refresh()
             {
-                if (Memory.State.Characters != null && Character != Characters.Blank)
+                if (Memory.State.Characters != null && Damageable != null)
                 {
                     base.Refresh();
                     FillData(Icons.ID.Icon_Status_Attack, Kernel_bin.Stat.ST_Atk, Kernel_bin.Stat.ST_Def_1);
@@ -83,7 +83,7 @@ namespace OpenVIII
                 //override this use it to take value of prevSetting and restore the setting unless default method works
                 if (GetPrevSetting() != null)
                 {
-                    Memory.State.Characters[Character] = GetPrevSetting().Clone();
+                    Damageable = GetPrevSetting().Clone();
                 }
             }
 

--- a/Core/Menu/IGM_Junction/IGMData/IGMData_Mag_ST_A_Values.cs
+++ b/Core/Menu/IGM_Junction/IGMData/IGMData_Mag_ST_A_Values.cs
@@ -25,10 +25,10 @@ namespace OpenVIII
 
             public override bool Update()
             {
-                if (Memory.State.Characters != null)
+                if (Memory.State.Characters != null && Damageable.GetCharacterData(out Saves.CharacterData c))
                 {
                     Dictionary<Kernel_bin.J_Statuses, byte> oldtotal = (prevSetting != null) ? getTotal(prevSetting, out Enum[] availableFlagsarray) : null;
-                    Dictionary<Kernel_bin.J_Statuses, byte> total = getTotal(Memory.State.Characters[Character], out availableFlagsarray);
+                    Dictionary<Kernel_bin.J_Statuses, byte> total = getTotal(c, out availableFlagsarray);
                     FillData(oldtotal, total, availableFlagsarray, Icons.ID.Status_Death, palette: 10, skip: new Icons.ID[] { Icons.ID.Status_Curse });
                 }
                 return base.Update();

--- a/Core/Menu/IGM_Junction/IGMData/IGMData_Mag_ST_D_Values.cs
+++ b/Core/Menu/IGM_Junction/IGMData/IGMData_Mag_ST_D_Values.cs
@@ -31,10 +31,10 @@ namespace OpenVIII
 
             public override bool Update()
             {
-                if (Memory.State.Characters != null)
+                if (Memory.State.Characters != null && Damageable.GetCharacterData(out Saves.CharacterData c))
                 {
                     Dictionary<Kernel_bin.J_Statuses, byte> oldtotal = (prevSetting != null) ? getTotal(prevSetting, out Enum[] availableFlagsarray) : null;
-                    Dictionary<Kernel_bin.J_Statuses, byte> total = getTotal(Memory.State.Characters[Character], out availableFlagsarray);
+                    Dictionary<Kernel_bin.J_Statuses, byte> total = getTotal(c, out availableFlagsarray);
                     FillData(oldtotal, total, availableFlagsarray, Icons.ID.Status_Death, 1, palette: 10);
                 }
                 return base.Update();

--- a/Core/Menu/IGM_Junction/IGMData/IGMData_Mag_Stat_Slots.cs
+++ b/Core/Menu/IGM_Junction/IGMData/IGMData_Mag_Stat_Slots.cs
@@ -40,7 +40,7 @@ namespace OpenVIII
 
             #region Methods
 
-            public override void BackupSetting() => SetPrevSetting(Memory.State.Characters[Character].Clone());
+            public override void BackupSetting() => SetPrevSetting((Saves.CharacterData)Damageable.Clone());
 
             public override void CheckMode(bool cursor = true) =>
                CheckMode(-1, Mode.None, Mode.Mag_Stat,
@@ -106,9 +106,9 @@ namespace OpenVIII
                 skipdata = true;
                 base.Inputs_Menu();
                 skipdata = false;
-                if (Contents[CURSOR_SELECT] == Kernel_bin.Stat.None)
+                if (Contents[CURSOR_SELECT] == Kernel_bin.Stat.None && Damageable.GetCharacterData(out Saves.CharacterData c))
                 {
-                    Memory.State.Characters[Character].Stat_J[Contents[CURSOR_SELECT]] = 0;
+                    c.Stat_J[Contents[CURSOR_SELECT]] = 0;
                     IGM_Junction.Refresh();
                 }
             }
@@ -140,12 +140,12 @@ namespace OpenVIII
                         BLANKS[5] = true;
                         foreach (Kernel_bin.Stat stat in (Kernel_bin.Stat[])Enum.GetValues(typeof(Kernel_bin.Stat)))
                         {
-                            if (Stat2Icon.ContainsKey(stat))
+                            if (Stat2Icon.ContainsKey(stat) && Damageable.GetCharacterData(out Saves.CharacterData c))
                             {
                                 int pos = (int)stat;
                                 if (pos >= 5) pos++;
                                 Contents[pos] = stat;
-                                FF8String name = Kernel_bin.MagicData[Memory.State.Characters[Character].Stat_J[stat]].Name;
+                                FF8String name = Kernel_bin.MagicData[c.Stat_J[stat]].Name;
                                 if (name == null || name.Length == 0) name = Misc[Items._];
 
                                 ITEM[pos, 0] = new IGMDataItem_Icon(Stat2Icon[stat], new Rectangle(SIZE[pos].X, SIZE[pos].Y, 0, 0), 2);
@@ -158,15 +158,15 @@ namespace OpenVIII
                                 }
                                 else BLANKS[pos] = false;
 
-                                ITEM[pos, 2] = new IGMDataItem_Int(Memory.State.Characters[Character].TotalStat(stat, VisibleCharacter), new Rectangle(SIZE[pos].X + 152, SIZE[pos].Y, 0, 0), 2, Icons.NumType.sysFntBig, spaces: 10);
+                                ITEM[pos, 2] = new IGMDataItem_Int(Damageable.TotalStat(stat), new Rectangle(SIZE[pos].X + 152, SIZE[pos].Y, 0, 0), 2, Icons.NumType.sysFntBig, spaces: 10);
                                 ITEM[pos, 3] = stat == Kernel_bin.Stat.HIT || stat == Kernel_bin.Stat.EVA
                                     ? new IGMDataItem_String(Misc[Items.Percent], new Rectangle(SIZE[pos].X + 350, SIZE[pos].Y, 0, 0))
                                     : null;
-                                if (GetPrevSetting() == null || GetPrevSetting().Stat_J[stat] == Memory.State.Characters[Character].Stat_J[stat] || GetPrevSetting().TotalStat(stat, VisibleCharacter) == Memory.State.Characters[Character].TotalStat(stat, VisibleCharacter))
+                                if (GetPrevSetting() == null || (Damageable.GetCharacterData(out Saves.CharacterData _c) && GetPrevSetting().Stat_J[stat] == _c.Stat_J[stat]) || GetPrevSetting().TotalStat(stat) == Damageable.TotalStat(stat))
                                 {
                                     ITEM[pos, 4] = null;
                                 }
-                                else if (GetPrevSetting().TotalStat(stat, VisibleCharacter) > Memory.State.Characters[Character].TotalStat(stat, VisibleCharacter))
+                                else if (GetPrevSetting().TotalStat(stat) > Damageable.TotalStat(stat))
                                 {
                                     ((IGMDataItem_Icon)ITEM[pos, 0]).Palette = 5;
                                     ((IGMDataItem_Icon)ITEM[pos, 0]).Faded_Palette = 5;
@@ -197,7 +197,7 @@ namespace OpenVIII
                 //override this use it to take value of prevSetting and restore the setting unless default method works
                 if (GetPrevSetting() != null)
                 {
-                    Memory.State.Characters[Character] = GetPrevSetting().Clone();
+                    Damageable = GetPrevSetting().Clone();
                 }
             }
 

--- a/Core/Menu/IGM_Junction/IGMData/IGMData_Mag_Stat_Slots.cs
+++ b/Core/Menu/IGM_Junction/IGMData/IGMData_Mag_Stat_Slots.cs
@@ -40,7 +40,11 @@ namespace OpenVIII
 
             #region Methods
 
-            public override void BackupSetting() => SetPrevSetting((Saves.CharacterData)Damageable.Clone());
+            public override void BackupSetting()
+            {
+                if(Damageable.GetCharacterData(out Saves.CharacterData c))
+                SetPrevSetting((Saves.CharacterData)c.Clone());
+            }
 
             public override void CheckMode(bool cursor = true) =>
                CheckMode(-1, Mode.None, Mode.Mag_Stat,
@@ -195,9 +199,10 @@ namespace OpenVIII
             public override void UndoChange()
             {
                 //override this use it to take value of prevSetting and restore the setting unless default method works
-                if (GetPrevSetting() != null)
+                if (GetPrevSetting() != null && Damageable.GetCharacterData(out Saves.CharacterData c) && GetPrevSetting().GetCharacterData(out Saves.CharacterData prevc))
                 {
-                    Damageable = GetPrevSetting().Clone();
+                    c.Magics = prevc.CloneMagic();
+                    c.Stat_J = prevc.CloneMagicJunction();
                 }
             }
 
@@ -206,7 +211,7 @@ namespace OpenVIII
                 if (!eventAdded)
                 {
                     IGMData_Mag_Pool.SlotConfirmListener += ConfirmChangeEvent;
-                    IGMData_Mag_Pool.SlotReinitListener += ReInitEvent;
+                    IGMData_Mag_Pool.SlotRefreshListener += ReInitEvent;
                     IGMData_Mag_Pool.SlotUndoListener += UndoChangeEvent;
                 }
                 base.AddEventListener();
@@ -249,7 +254,7 @@ namespace OpenVIII
 
             private void ConfirmChangeEvent(object sender, Mode e) => ConfirmChange();
 
-            private void ReInitEvent(object sender, Mode e) => Refresh();
+            private void ReInitEvent(object sender, Damageable e) => Refresh(e);
 
             private void UndoChangeEvent(object sender, Mode e) => UndoChange();
 

--- a/Core/Menu/IGM_Junction/IGMData/IGMData_Slots.cs
+++ b/Core/Menu/IGM_Junction/IGMData/IGMData_Slots.cs
@@ -94,9 +94,9 @@ namespace OpenVIII
 
             public override void Refresh()
             {
-                if (Character != Characters.Blank)
+                if (Damageable != null && Damageable.GetCharacterData(out Saves.CharacterData c))
                 {
-                    unlocked = Memory.State.Characters[Character].UnlockedGFAbilities;
+                    unlocked = c.UnlockedGFAbilities;
                     AddEventListener();
                     CheckMode();
                     base.Refresh();
@@ -120,10 +120,11 @@ namespace OpenVIII
 
             protected void FillData(Icons.ID starticon, Kernel_bin.Stat statatk, Kernel_bin.Stat statdef)
             {
+                if (!Damageable.GetCharacterData(out Saves.CharacterData c)) return;
                 byte pos = 0;
                 Contents[0] = statatk;
                 getColor(pos, out byte palette, out Font.ColorID _colorid, out bool unlocked);
-                FF8String name = Kernel_bin.MagicData[Memory.State.Characters[Character].Stat_J[statatk]].Name;
+                FF8String name = Kernel_bin.MagicData[c.Stat_J[statatk]].Name;
                 if (name == null || name.Length == 0)
                     name = Misc[Items._];
                 ITEM[pos, 0] = new IGMDataItem_Icon(starticon, new Rectangle(SIZE[pos].X, SIZE[pos].Y, 0, 0), palette);
@@ -133,7 +134,7 @@ namespace OpenVIII
                 {
                     Contents[pos] = statdef + pos - 1;
                     getColor(pos, out palette, out _colorid, out unlocked);
-                    name = Kernel_bin.MagicData[Memory.State.Characters[Character].Stat_J[statdef + pos - 1]].Name;
+                    name = Kernel_bin.MagicData[c.Stat_J[statdef + pos - 1]].Name;
                     if (name == null || name.Length == 0)
                         name = Misc[Items._];
                     ITEM[pos, 0] = new IGMDataItem_Icon(starticon + 1, new Rectangle(SIZE[pos].X, SIZE[pos].Y, 0, 0), palette);

--- a/Core/Menu/IGM_Junction/IGMData/IGMData_TopMenu.cs
+++ b/Core/Menu/IGM_Junction/IGMData/IGMData_TopMenu.cs
@@ -27,7 +27,7 @@ namespace OpenVIII
 
             public override bool Inputs_CANCEL()
             {
-                if (Memory.PrevState != null && Memory.PrevState.Characters[VisibleCharacter].CurrentHP() > Memory.State.Characters[VisibleCharacter].CurrentHP())
+                if (Memory.PrevState != null && Damageable.CurrentHP() > Damageable.CurrentHP())
                 {
                     IGM_Junction.Data[SectionName.ConfirmChanges].Show();
                     IGM_Junction.SetMode(Mode.ConfirmChanges);
@@ -82,15 +82,15 @@ namespace OpenVIII
 
             public override void Refresh()
             {
-                if (Memory.State.Characters != null)
+                if (Memory.State.Characters != null && Damageable.GetCharacterData(out Saves.CharacterData c))
                 {
-                    Font.ColorID color = (Memory.State.Characters[Character].JunctionnedGFs == Saves.GFflags.None) ? Font.ColorID.Grey : Font.ColorID.White;
+                    Font.ColorID color = (c.JunctionnedGFs == Saves.GFflags.None) ? Font.ColorID.Grey : Font.ColorID.White;
 
                     ITEM[1, 0] = new IGMDataItem_String(Titles[Items.Off], SIZE[1], color);
                     ITEM[2, 0] = new IGMDataItem_String(Titles[Items.Auto], SIZE[2], color);
                     ITEM[3, 0] = new IGMDataItem_String(Titles[Items.Ability], SIZE[3], color);
                     for (int i = 1; i <= 3; i++)
-                        BLANKS[i] = Memory.State.Characters[Character].JunctionnedGFs == Saves.GFflags.None;
+                        BLANKS[i] = c.JunctionnedGFs == Saves.GFflags.None;
                 }
                 base.Refresh();
             }

--- a/Core/Menu/IGM_Junction/IGMData/IGMData_TopMenu.cs
+++ b/Core/Menu/IGM_Junction/IGMData/IGMData_TopMenu.cs
@@ -28,8 +28,9 @@ namespace OpenVIII
             public override bool Inputs_CANCEL()
             {
                 if (Memory.PrevState != null && 
-                    Damageable.GetCharacterData(out Saves.CharacterData c) && 
-                    Memory.PrevState.Characters[c.ID].CurrentHP() > Memory.State.Characters[c.ID].CurrentHP())
+                    Damageable.GetCharacterData(out Saves.CharacterData c) && (
+                    Memory.PrevState.Characters[c.ID].CurrentHP() > Memory.State.Characters[c.ID].CurrentHP() ||
+                    Memory.PrevState.Characters[c.ID].MaxHP() > Memory.State.Characters[c.ID].MaxHP()))
                 {
                     IGM_Junction.Data[SectionName.ConfirmChanges].Show();
                     IGM_Junction.SetMode(Mode.ConfirmChanges);

--- a/Core/Menu/IGM_Junction/IGMData/IGMData_TopMenu.cs
+++ b/Core/Menu/IGM_Junction/IGMData/IGMData_TopMenu.cs
@@ -27,7 +27,9 @@ namespace OpenVIII
 
             public override bool Inputs_CANCEL()
             {
-                if (Memory.PrevState != null && Damageable.CurrentHP() > Damageable.CurrentHP())
+                if (Memory.PrevState != null && 
+                    Damageable.GetCharacterData(out Saves.CharacterData c) && 
+                    Memory.PrevState.Characters[c.ID].CurrentHP() > Memory.State.Characters[c.ID].CurrentHP())
                 {
                     IGM_Junction.Data[SectionName.ConfirmChanges].Show();
                     IGM_Junction.SetMode(Mode.ConfirmChanges);

--- a/Core/Menu/IGM_Junction/IGMData/IGMData_TopMenu_Auto.cs
+++ b/Core/Menu/IGM_Junction/IGMData/IGMData_TopMenu_Auto.cs
@@ -35,18 +35,19 @@ namespace OpenVIII
 
             public override bool Inputs_OKAY()
             {
+                if (Damageable.GetCharacterData(out Saves.CharacterData c))
                 switch (CURSOR_SELECT)
                 {
                     case 0:
-                        Memory.State.Characters[Character].AutoATK();
+                        c.AutoATK();
                         break;
 
                     case 1:
-                        Memory.State.Characters[Character].AutoDEF();
+                        c.AutoDEF();
                         break;
 
                     case 2:
-                        Memory.State.Characters[Character].AutoMAG();
+                        c.AutoMAG();
                         break;
                     default: return false;
                 }

--- a/Core/Menu/IGM_Junction/IGMData/IGMData_Values.cs
+++ b/Core/Menu/IGM_Junction/IGMData/IGMData_Values.cs
@@ -134,10 +134,10 @@ namespace OpenVIII
                             flags = Kernel_bin.MagicData[spell[i]].ST_Def;
                             break;
                     }
-                    if (flags != null)
+                    if (flags != null && Damageable.GetCharacterData(out Saves.CharacterData c))
                         foreach (Enum flag in availableFlags.Where(flags.HasFlag))
                         {
-                            int t = total[(T)flag] + ((Kernel_bin.MagicData[spell[i]].J_Val[stat] * Memory.State.Characters[Character].Magics[spell[i]]) / 100);
+                            int t = total[(T)flag] + ((Kernel_bin.MagicData[spell[i]].J_Val[stat] * c.Magics[spell[i]]) / 100);
                             total[(T)flag] = (byte)MathHelper.Clamp(t,0,max);
                         }
                     else

--- a/Core/Menu/Menu.cs
+++ b/Core/Menu/Menu.cs
@@ -72,7 +72,7 @@ namespace OpenVIII
 
         public Menu(Damageable damageable)
         {
-            Damageable = damageable;
+            _damageable = damageable;
             InitConstructor(); // because base() would always run first :(
         }
 

--- a/Core/Menu/Menu.cs
+++ b/Core/Menu/Menu.cs
@@ -70,10 +70,9 @@ namespace OpenVIII
 
         public Menu() => InitConstructor();
 
-        public Menu(Characters character, Characters? Visiblecharacter = null)
+        public Menu(Damageable damageable)
         {
-            Character = character;
-            VisibleCharacter = Visiblecharacter ?? character;
+            Damageable = damageable;
             InitConstructor(); // because base() would always run first :(
         }
 
@@ -355,14 +354,14 @@ namespace OpenVIII
             base.Refresh();
         }
 
-        public void Refresh(bool backup) => Refresh(Character, VisibleCharacter, backup);
+        public void Refresh(bool backup) => Refresh(Damageable, backup);
 
-        public override void Refresh(Characters character, Characters? Visiblecharacter = null) => Refresh(character, Visiblecharacter ?? character, false);
+        public override void Refresh(Damageable damageable) => Refresh(damageable, false);
 
-        public virtual void Refresh(Characters c, Characters vc, bool backup)
+        public virtual void Refresh(Damageable damageable, bool backup)
         {
             _backup = backup;
-            base.Refresh(c, vc);
+            base.Refresh(damageable);
         }
 
         public virtual bool SetMode(Enum mode)
@@ -434,7 +433,7 @@ namespace OpenVIII
         {
             if (!skipdata)
                 foreach (KeyValuePair<Enum, IGMData> i in Data)
-                    i.Value.Refresh(Character, VisibleCharacter);
+                    i.Value.Refresh(Damageable);
         }
 
         private void Backup()

--- a/Core/Menu/Menu_Base.cs
+++ b/Core/Menu/Menu_Base.cs
@@ -7,6 +7,7 @@ namespace OpenVIII
     /// </summary>
     public abstract class Menu_Base
     {
+        protected Damageable _damageable;
         #region Properties
 
         /// <summary>
@@ -18,7 +19,7 @@ namespace OpenVIII
         /// <summary>
         /// Characters/Enemies/GF
         /// </summary>
-        public Damageable Damageable { get; protected set; }
+        public Damageable Damageable { get => _damageable; }
 
 
 
@@ -60,9 +61,9 @@ namespace OpenVIII
         /// <param name="Visiblecharacter"></param>
         public virtual void Refresh(Damageable damageable)
         {
-            if(damageable != null )
+            if (damageable != null)
             {
-                Damageable = damageable;
+                _damageable = damageable;
 
                 if (Damageable.GetCharacterData(out Saves.CharacterData c))
                 {

--- a/Core/Menu/Menu_Base.cs
+++ b/Core/Menu/Menu_Base.cs
@@ -16,14 +16,11 @@ namespace OpenVIII
         public bool Enabled { get; private set; } = true;
 
         /// <summary>
-        /// Character who has the junctions and inventory. Same as VisibleCharacter unless TeamLaguna.
+        /// Characters/Enemies/GF
         /// </summary>
-        public Characters Character { get; protected set; } = Characters.Blank;
+        public Damageable Damageable { get; protected set; }
 
-        /// <summary>
-        /// Required to support Laguna's Party. They have unique stats but share junctions and inventory.
-        /// </summary>
-        public Characters VisibleCharacter { get; protected set; } = Characters.Blank;
+
 
         /// <summary>
         /// Position of party member 0,1,2. If -1 at the time of setting the character wasn't in the party.
@@ -61,13 +58,16 @@ namespace OpenVIII
         /// </summary>
         /// <param name="character"></param>
         /// <param name="Visiblecharacter"></param>
-        public virtual void Refresh(Characters character, Characters? Visiblecharacter = null)
+        public virtual void Refresh(Damageable damageable)
         {
-            if ((character != Character || (Visiblecharacter ?? character) != VisibleCharacter) && character != Characters.Blank && Visiblecharacter != Characters.Blank)
+            if(damageable != null )
             {
-                Character = character;
-                VisibleCharacter = Visiblecharacter ?? character;
-                PartyPos = (sbyte)(Memory.State?.PartyData?.Where(x => !x.Equals(Characters.Blank)).ToList().FindIndex(x => x.Equals(Character)) ?? -1);
+                Damageable = damageable;
+
+                if (Damageable.GetCharacterData(out Saves.CharacterData c))
+                {
+                    PartyPos = (sbyte)(Memory.State?.PartyData?.Where(x => !x.Equals(Characters.Blank)).ToList().FindIndex(x => x.Equals(c.ID)) ?? -1);
+                }
             }
             Refresh();
         }

--- a/Core/Saves/Damageable.cs
+++ b/Core/Saves/Damageable.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 
 namespace OpenVIII
 {
@@ -17,8 +16,6 @@ namespace OpenVIII
         private Kernel_bin.Battle_Only_Statuses _statuses1;
         private Dictionary<Kernel_bin.Attack_Type, Func<Kernel_bin.Persistant_Statuses, Kernel_bin.Battle_Only_Statuses, Kernel_bin.Attack_Flags, int>> _statusesActions;
 
-        public abstract Damageable Clone();
-
         protected ushort _CurrentHP;
 
         /// <summary>
@@ -30,8 +27,6 @@ namespace OpenVIII
         #endregion Fields
 
         #region Properties
-
-        
 
         public IReadOnlyDictionary<Kernel_bin.Attack_Type, Func<int, Kernel_bin.Attack_Flags, int>> DamageActions
         {
@@ -193,10 +188,15 @@ namespace OpenVIII
         }
 
         public abstract byte EVA { get; }
+
         public abstract int EXP { get; }
+
         public abstract byte HIT { get; }
+
         public ushort HP => CurrentHP();
+
         public bool IsDead => CurrentHP() == 0 || (Statuses0 & Kernel_bin.Persistant_Statuses.Death) != 0;
+
         /// <summary>
         /// If all partymemembers are in gameover trigger Phoenix Pinion if CanPhoenixPinion or
         /// trigger Game over
@@ -216,9 +216,13 @@ namespace OpenVIII
             (Statuses0 & Kernel_bin.Persistant_Statuses.Berserk) != 0;
 
         public bool IsPetrify => (Statuses0 & (Kernel_bin.Persistant_Statuses.Petrify)) != 0;
+
         public abstract byte Level { get; }
+
         public abstract byte LUCK { get; }
+
         public abstract byte MAG { get; }
+
         /// <summary>
         /// Name
         /// </summary>
@@ -226,7 +230,9 @@ namespace OpenVIII
         public virtual FF8String Name { get; set; }
 
         public abstract byte SPD { get; }
+
         public abstract byte SPR { get; }
+
         /// <summary>
         /// Persistant_Statuses are saved and last between battles.
         /// </summary>
@@ -419,16 +425,7 @@ namespace OpenVIII
         #endregion Properties
 
         #region Methods
-        public bool GetCharacterData(out Saves.CharacterData characterData)
-        {
-            if (GetType() == typeof(Saves.CharacterData))
-            {
-                characterData = (Saves.CharacterData)this;
-                return true;
-            }
-            characterData = null;
-            return false;
-        }
+
         /// <summary>
         /// Starting value
         /// </summary>
@@ -503,6 +500,8 @@ namespace OpenVIII
             return true;
         }
 
+        public abstract Damageable Clone();
+
         public virtual bool Critical() => CurrentHP() <= CriticalHP();
 
         public virtual ushort CriticalHP() => (ushort)((MaxHP() / 4) - 1);
@@ -553,6 +552,25 @@ namespace OpenVIII
 
         public abstract short ElementalResistance(Kernel_bin.Element @in);
 
+        public bool GetCharacterData(out Saves.CharacterData character)
+        => GetCast(out character);
+
+        public bool GetEnemy(out Enemy enemy)
+        => GetCast(out enemy);
+
+        public bool GetGFData(out Saves.GFData gf)
+        => GetCast(out gf);
+
+        public bool GetCast<T>(out T cast) where T: Damageable
+        {
+            if (GetType() == typeof(T))
+            {
+                cast = (T)this;
+                return true;
+            }
+            cast = null;
+            return false;
+        }
         public SpeedMod GetSpeedMod()
         {
             if ((Statuses1 & Kernel_bin.Battle_Only_Statuses.Haste) != 0)
@@ -585,7 +603,6 @@ namespace OpenVIII
         public int TimeToFillBarGF() => TimeToFillBarGF(SPD);
 
         public abstract ushort TotalStat(Kernel_bin.Stat s);
-
 
         #endregion Methods
     }

--- a/Core/Saves/Damageable.cs
+++ b/Core/Saves/Damageable.cs
@@ -5,6 +5,9 @@ using System.Linq;
 
 namespace OpenVIII
 {
+    /// <summary>
+    /// Character/Enemy/GF that can be damaged or die.
+    /// </summary>
     public abstract class Damageable : IDamageable
     {
         #region Fields
@@ -13,6 +16,8 @@ namespace OpenVIII
         private Kernel_bin.Persistant_Statuses _statuses0;
         private Kernel_bin.Battle_Only_Statuses _statuses1;
         private Dictionary<Kernel_bin.Attack_Type, Func<Kernel_bin.Persistant_Statuses, Kernel_bin.Battle_Only_Statuses, Kernel_bin.Attack_Flags, int>> _statusesActions;
+
+        public abstract Damageable Clone();
 
         protected ushort _CurrentHP;
 
@@ -414,7 +419,16 @@ namespace OpenVIII
         #endregion Properties
 
         #region Methods
-
+        public bool GetCharacterData(out Saves.CharacterData characterData)
+        {
+            if (GetType() == typeof(Saves.CharacterData))
+            {
+                characterData = (Saves.CharacterData)this;
+                return true;
+            }
+            characterData = null;
+            return false;
+        }
         /// <summary>
         /// Starting value
         /// </summary>

--- a/Core/Saves/ICharacterData.cs
+++ b/Core/Saves/ICharacterData.cs
@@ -26,7 +26,6 @@ namespace OpenVIII
         List<Kernel_bin.Abilities> UnlockedGFAbilities { get; }
 
         void BattleStart(Module_battle_debug.CharacterInstanceInformation cii);
-        Saves.CharacterData Clone();
         int CriticalHP(Characters value);
         ushort CurrentHP(Characters c);
         sbyte GenerateCrisisLevel();

--- a/Core/Saves/Saves.CharacterData.cs
+++ b/Core/Saves/Saves.CharacterData.cs
@@ -113,6 +113,9 @@ namespace OpenVIII
                 }
             }
 
+            public OrderedDictionary<byte, byte> CloneMagic() => Magics.Clone();
+            public Dictionary<Kernel_bin.Stat, byte> CloneMagicJunction() => new Dictionary<Kernel_bin.Stat, byte>(Stat_J);
+
             #endregion Methods
 
             /// <summary>

--- a/Core/Saves/Saves.CharacterData.cs
+++ b/Core/Saves/Saves.CharacterData.cs
@@ -71,6 +71,7 @@ namespace OpenVIII
         public class CharacterData : Damageable, ICharacterData
         {
             #region Fields
+
             /// <summary>
             /// Total amount of spells the will be loaded/saved.
             /// </summary>
@@ -238,21 +239,35 @@ namespace OpenVIII
             }
 
             public ushort ExperienceToNextLevel => (ushort)(Level == 100 ? 0 : MathHelper.Clamp(CharacterStats.EXP((byte)(Level + 1)) - Experience, 0, CharacterStats.EXP(2)));
-
-            public Characters ID { get; private set; }
+            private Characters id;
+            /// <summary>
+            /// If TeamLaguna the id will change to a Luguna Party member
+            /// </summary>
+            public Characters ID
+            {
+                get
+                {
+                    int ind = 0;
+                    if (Memory.State != null && Memory.State.TeamLaguna && (ind = Memory.State.PartyData.FindIndex(x => x.Equals(id))) >= 0 && !Memory.State.Party.Contains(id))
+                        return Memory.State.Party[ind];
+                    return id;
+                }
+            }
 
             public bool IsCritical => CurrentHP() <= CriticalHP();
 
             public override byte Level => CharacterStats.LEVEL(Experience);
 
+            /// <summary>
+            /// If TeamLaguna the name will change to a Luguna Party member
+            /// </summary>
             public override FF8String Name
             {
                 get
                 {
-                    int ind = 0;
-                    if (Memory.State != null && Memory.State.TeamLaguna && (ind = Memory.State.PartyData.FindIndex(x => x.Equals(ID))) >= 0 && !Memory.State.Party.Contains(ID))
+                    if (Memory.State != null && Memory.State.TeamLaguna)
                     {
-                        return Memory.Strings.GetName(Memory.State.Party[ind]);
+                        return Memory.Strings.GetName(ID);
                     }
                     return base.Name;
                 }
@@ -290,7 +305,7 @@ namespace OpenVIII
             /// <summary>
             /// Kernel Stats
             /// </summary>
-            public Kernel_bin.Character_Stats CharacterStats => Kernel_bin.CharacterStats[ID];
+            public Kernel_bin.Character_Stats CharacterStats => Kernel_bin.CharacterStats[id];
 
             public override byte EVA => checked((byte)TotalStat(Kernel_bin.Stat.EVA));
 
@@ -333,7 +348,7 @@ namespace OpenVIII
                     Statuses1 |= Kernel_bin.Battle_Only_Statuses.Shell;
             }
 
-            public CharacterData Clone()
+            public override Damageable Clone()
             {
                 //Shadowcopy
                 CharacterData c = (CharacterData)MemberwiseClone();
@@ -352,15 +367,7 @@ namespace OpenVIII
 
             public int CriticalHP(Characters value) => MaxHP(value) / 4 - 1;
 
-            public override ushort CurrentHP()
-            {
-                int ind = -1;
-                if (Memory.State?.Characters != null && Memory.State.TeamLaguna && (ind = Memory.State.PartyData.FindIndex(u => u == ID)) >= 0)
-                {
-                    return CurrentHP(Memory.State.Party[ind]);
-                }
-                return CurrentHP(ID);
-            }
+            public override ushort CurrentHP() => CurrentHP(ID);
 
             public ushort CurrentHP(Characters c)
             {
@@ -385,7 +392,7 @@ namespace OpenVIII
             {
                 ushort current = CurrentHP();
                 ushort max = MaxHP();
-                //if ((ID == Characters.Seifer_Almasy && CurrentHP() < (max * 84 / 100)))
+                //if ((id == Characters.Seifer_Almasy && CurrentHP() < (max * 84 / 100)))
                 //{
                 int HPMod = CharacterStats.Crisis * 10 * current / max;
                 int DeathBonus = Memory.State.DeadPartyMembers() * 200 + 1600;
@@ -435,32 +442,16 @@ namespace OpenVIII
             /// <returns></returns>
             public ushort MaxHP(Characters c) => TotalStat(Kernel_bin.Stat.HP, c);
 
-            public override ushort MaxHP()
-            {
-                int ind = -1;
-                if (Memory.State?.Characters != null && Memory.State.TeamLaguna && (ind = Memory.State.PartyData.FindIndex(u => u == ID)) >= 0)
-                {
-                    return MaxHP(Memory.State.Party[ind]);
-                }
-                return MaxHP(ID);
-            }
+            public override ushort MaxHP() => MaxHP(ID);
 
-            public override float PercentFullHP()
-            {
-                int ind = -1;
-                if (Memory.State?.Characters != null && Memory.State.TeamLaguna && (ind = Memory.State.PartyData.FindIndex(u => u == ID)) >= 0)
-                {
-                    return PercentFullHP(Memory.State.Party[ind]);
-                }
-                return PercentFullHP(ID);
-            }
+            public override float PercentFullHP() => PercentFullHP(ID);
 
             public float PercentFullHP(Characters c) => (float)CurrentHP(c) / MaxHP(c);
 
             public void Read(BinaryReader br, Characters c)
             {
                 //Name = Memory.Strings.GetName(c, data);
-                ID = c;
+                id = c;
                 _CurrentHP = br.ReadUInt16();//0x00
                 _HP = br.ReadUInt16();//0x02
                 Experience = br.ReadUInt32();//0x04
@@ -537,9 +528,9 @@ namespace OpenVIII
             public ushort TotalStat(Kernel_bin.Stat s, Characters c = Characters.Blank)
             {
                 if (c == Characters.Blank)
-                    c = ID;
-                if (c != ID && c < Characters.Laguna_Loire)
-                    throw new ArgumentException($"{this}::Wrong visible character value({c}). Must match ({ID}) unless Laguna Kiros or Ward!");
+                    c = id;
+                if (c != id && c < Characters.Laguna_Loire)
+                    throw new ArgumentException($"{this}::Wrong visible character value({c}). Must match ({id}) unless Laguna Kiros or Ward!");
                 int total = 0;
                 foreach (Kernel_bin.Abilities i in Abilities)
                 {
@@ -580,7 +571,7 @@ namespace OpenVIII
                 return 0;
             }
 
-            public override ushort TotalStat(Kernel_bin.Stat s) => throw new NotImplementedException();
+            public override ushort TotalStat(Kernel_bin.Stat s) => TotalStat(s,ID);
 
             public bool Unlocked(Kernel_bin.Stat stat) => Unlocked(UnlockedGFAbilities, stat);
 
@@ -624,6 +615,7 @@ namespace OpenVIII
                         return unlocked.Contains(Kernel_bin.Abilities.ST_Def_Jx4);
                 }
             }
+
         }
 
         #endregion Classes

--- a/Core/Saves/Saves.Data.cs
+++ b/Core/Saves/Saves.Data.cs
@@ -26,7 +26,7 @@ namespace OpenVIII
 
             #region Methods
 
-            private CharacterData GetDamagable(Characters id)
+            private CharacterData GetDamageable(Characters id)
             {
                 if (!Characters.TryGetValue(id, out CharacterData c))
                 {
@@ -38,16 +38,16 @@ namespace OpenVIII
                 return c;
             }
 
-            private GFData GetDamagable(GFs id) => GFs.ContainsKey(id) ? GFs[id] : null;
+            private GFData GetDamageable(GFs id) => GFs.ContainsKey(id) ? GFs[id] : null;
 
-            private Damageable GetDamagable(Faces.ID id)
+            private Damageable GetDamageable(Faces.ID id)
             {
                 GFs gf = id.ToGFs();
                 Characters c = id.ToCharacters();
                 if (c == OpenVIII.Characters.Blank)
-                    return GetDamagable(gf);
+                    return GetDamageable(gf);
                 else
-                    return GetDamagable(c);
+                    return GetDamageable(c);
             }
 
             #endregion Methods
@@ -489,11 +489,13 @@ namespace OpenVIII
 
             #region Indexers
 
-            public GFData this[GFs id] => GetDamagable(id);
+            public GFData this[GFs id] => GetDamageable(id);
 
-            public CharacterData this[Characters id] => GetDamagable(id);
+            public CharacterData this[Characters id] => GetDamageable(id);
 
-            public Damageable this[Faces.ID id] => GetDamagable(id);
+            public Damageable this[Faces.ID id] => GetDamageable(id);
+
+            //public Damageable this[Damageable damageable]
 
             #endregion Indexers
 
@@ -508,9 +510,9 @@ namespace OpenVIII
                 //deepcopy anything that needs it here.
 
                 d.Characters = Characters.ToDictionary(entry => entry.Key,
-                    entry => entry.Value.Clone());
+                    entry => (CharacterData)entry.Value.Clone());
                 d.GFs = GFs.ToDictionary(entry => entry.Key,
-                    entry => entry.Value.Clone());
+                    entry => (GFData)entry.Value.Clone());
                 d.ChocoboWorld = ChocoboWorld.Clone();
                 d.Fieldvars = Fieldvars.Clone();
                 d.Worldmap = Worldmap.Clone();

--- a/Core/Saves/Saves.Data.cs
+++ b/Core/Saves/Saves.Data.cs
@@ -28,14 +28,15 @@ namespace OpenVIII
 
             private CharacterData GetDamageable(Characters id)
             {
-                if (!Characters.TryGetValue(id, out CharacterData c))
+                if (Characters != null && !Characters.TryGetValue(id, out CharacterData c))
                 {
                     var ind = Party.FindIndex(x=>x.Equals(id));
 
                     if (ind == -1 || !Characters.TryGetValue(PartyData[ind], out c))
                         throw new ArgumentException($"{this}::Cannot find {id} in CharacterData or Party");
+                    return c;
                 }
-                return c;
+                return null;
             }
 
             private GFData GetDamageable(GFs id) => GFs.ContainsKey(id) ? GFs[id] : null;

--- a/Core/Saves/Saves.Data.cs
+++ b/Core/Saves/Saves.Data.cs
@@ -21,6 +21,10 @@ namespace OpenVIII
 
             private TimeSpan _gametime;
             private TimeSpan _timeplayed;
+            private Dictionary<Characters, CharacterData> _characters;
+            private Dictionary<GFs, GFData> _gfs;
+            private List<Shop> _shops;
+            private List<Item> _items;
 
             #endregion Fields
 
@@ -31,7 +35,7 @@ namespace OpenVIII
                 CharacterData c = null;
                 if (Characters != null && !Characters.TryGetValue(id, out c))
                 {
-                    var ind = Party.FindIndex(x=>x.Equals(id));
+                    var ind = Party.FindIndex(x => x.Equals(id));
 
                     if (ind == -1 || !Characters.TryGetValue(PartyData[ind], out c))
                         throw new ArgumentException($"{this}::Cannot find {id} in CharacterData or Party");
@@ -168,7 +172,7 @@ namespace OpenVIII
             /// <summary>
             /// 0x04A0-0x08C7 152 bytes each 8 of them. Characters: Squall-Edea
             /// </summary>
-            public Dictionary<Characters, CharacterData> Characters { get; set; }
+            public IReadOnlyDictionary<Characters, CharacterData> Characters { get => (IReadOnlyDictionary<Characters, CharacterData>)_characters; }
 
             /// <summary>
             /// 0x1370 64 bytes Chocobo World (TODO)
@@ -250,7 +254,7 @@ namespace OpenVIII
             /// <summary>
             /// 0x0060 - 0x049F 68 bytes each 16 of them. Guardian Forces: Quetzalcoatl-Eden
             /// </summary>
-            public Dictionary<GFs, GFData> GFs { get; set; }
+            public IReadOnlyDictionary<GFs, GFData> GFs { get => _gfs; }
 
             /// <summary>
             /// 0x0B0C 12 bytes Griever name (FF8 text format)
@@ -263,7 +267,7 @@ namespace OpenVIII
             /// The order of items out of battle and Each item uses 2 bytes 1 for ID and 1 for Quantity
             /// </para>
             /// </summary>
-            public List<Item> Items { get; set; }
+            public IReadOnlyList<Item> Items { get => _items; }
 
             /// <summary>
             /// <para>0x0B34 32 bytes Items battle order</para>
@@ -394,7 +398,7 @@ namespace OpenVIII
             /// <summary>
             /// 0x0960-0x0AEF 400 total bytes 20 bytes each 20 of them. Shops
             /// </summary>
-            public List<Shop> Shops { get; set; }
+            public IReadOnlyList<Shop> Shops { get => _shops; }
 
             public bool SmallTeam
             {
@@ -511,21 +515,14 @@ namespace OpenVIII
                 Data d = (Data)MemberwiseClone();
                 //deepcopy anything that needs it here.
 
-                d.Characters = Characters.ToDictionary(entry => entry.Key,
-                    entry => (CharacterData)entry.Value.Clone());
-                d.GFs = GFs.ToDictionary(entry => entry.Key,
-                    entry => (GFData)entry.Value.Clone());
+                d._characters = _characters.ToDictionary(x => x.Key, x => (CharacterData)x.Value.Clone());
+                d._gfs = _gfs.ToDictionary(x => x.Key, x => (GFData)x.Value.Clone());
                 d.ChocoboWorld = ChocoboWorld.Clone();
                 d.Fieldvars = Fieldvars.Clone();
                 d.Worldmap = Worldmap.Clone();
                 d.TripleTriad = TripleTriad.Clone();
-                d.Shops = new List<Shop>(Shops.Count);
-                foreach (Shop s in Shops)
-                    d.Shops.Add(s.Clone());
-
-                d.Items = new List<Item>(Items.Count);
-                foreach (Item i in Items)
-                    d.Items.Add(i.Clone());
+                d._shops = _shops.Select(x => x.Clone()).ToList();
+                d._items = _items.Select(x => x.Clone()).ToList();
                 return d;
             }
 
@@ -590,7 +587,7 @@ namespace OpenVIII
             }
             public bool EarnItem(KeyValuePair<Cards.ID, byte> keyValuePair, byte location = 0)
             {
-                return EarnItem(keyValuePair.Key, keyValuePair.Value, location);                
+                return EarnItem(keyValuePair.Key, keyValuePair.Value, location);
             }
 
             public bool EarnItem(Item item)
@@ -649,8 +646,13 @@ namespace OpenVIII
             {
                 //Define Containers
                 Timeplayed = new TimeSpan();
-                GFs = new Dictionary<GFs, GFData>(16);
-                Characters = new Dictionary<Characters, CharacterData>(8);
+                _gfs = new Dictionary<GFs, GFData>(16);
+                _characters = new Dictionary<Characters, CharacterData>(8);
+                _shops = new List<Shop>(20); 
+                _items = new List<Item>(198);
+                CoordX = new short[3];
+                CoordY = new short[3];
+                Triangle_ID = new ushort[3];
 
                 //Read Data
                 LocationID = br.ReadUInt16();//0x0004
@@ -662,31 +664,33 @@ namespace OpenVIII
                 FirstCharactersLevel = br.ReadByte();//0x0024
                 Party = Array.ConvertAll(br.ReadBytes(3), Item => (Characters)Item).ToList();//0x0025//0x0026//0x0027 0xFF = blank.
                 Squallsname = br.ReadBytes(12);//0x0028
+                if (string.IsNullOrWhiteSpace(Squallsname)) Squallsname = Memory.Strings.GetName(Faces.ID.Squall_Leonhart);
                 Rinoasname = br.ReadBytes(12);//0x0034
+                if (string.IsNullOrWhiteSpace(Rinoasname)) Rinoasname = Memory.Strings.GetName(Faces.ID.Rinoa_Heartilly);
                 Angelosname = br.ReadBytes(12);//0x0040
+                if (string.IsNullOrWhiteSpace(Angelosname)) Angelosname = Memory.Strings.GetName(Faces.ID.Angelo);
                 Bokosname = br.ReadBytes(12);//0x004C
+                if (string.IsNullOrWhiteSpace(Bokosname)) Bokosname = Memory.Strings.GetName(Faces.ID.Boko);
                 CurrentDisk = br.ReadUInt32();//0x0058
                 Currentsave = br.ReadUInt32();//0x005C
                 for (byte i = 0; i <= (int)OpenVIII.GFs.Eden; i++)
                 {
-                    GFs[(GFs)i] = new GFData(br, (GFs)i);
+                    _gfs.Add((GFs)i,new GFData(br, (GFs)i));
                 }
                 for (byte i = 0; i <= (int)OpenVIII.Characters.Edea_Kramer; i++)
                 {
-
-                    Characters[(Characters)i] = new CharacterData(br, (Characters)i)
+                    _characters.Add((Characters)i,new CharacterData(br, (Characters)i)
                     {
                         Name = Memory.Strings.GetName((Characters)i, this)
-                    }; // 0x04A0 -> 0x08C8 //152 bytes per 8 total
+                    }); // 0x04A0 -> 0x08C8 //152 bytes per 8 total
                 }
-                Shops = new List<Shop>(20); //0x0960 //400 bytes
-                for (int i = 0; i < Shops.Capacity; i++)
-                    Shops.Add(new Shop(br));
+                for (int i = 0; i < _shops.Capacity; i++)
+                    _shops.Add(new Shop(br));//0x0960 //400 bytes
                 Configuration = br.ReadBytes(20); //0x0AF0 //20 bytes TODO break this up into a structure or class.
                 PartyData = Array.ConvertAll(br.ReadBytes(4), Item => (Characters)Item).ToList(); //0x0B04 // 4 bytes 0xFF terminated.
                 KnownWeapons = new BitArray(br.ReadBytes(4)); //0x0B08 // 4 bytes
                 Grieversname = br.ReadBytes(12); //0x0B0C // 12 bytes
-
+                if (string.IsNullOrWhiteSpace(Grieversname)) Grieversname = Memory.Strings.GetName(Faces.ID.Griever);
                 Unknown1 = br.ReadUInt16();//0x0B18  (always 7966?)
                 Unknown2 = br.ReadUInt16();//0x0B1A
                 AmountofGil2 = br.ReadUInt32();//0x0B1C //dupilicate
@@ -699,9 +703,8 @@ namespace OpenVIII
                 LimitBreakAngeloknown = new BitArray(br.ReadBytes(1));//0x0B2B
                 LimitBreakAngelopoints = br.ReadBytes(8);//0x0B2C
                 Itemsbattleorder = br.ReadBytes(32);//0x0B34
-                Items = new List<Item>(198);
-                for (int i = 0; i < 198; i++)
-                    Items.Add(new Item(br.ReadByte(), br.ReadByte())); //0x0B54 198 items (Item ID and Quantity)
+                for (int i = 0; i < _items.Capacity; i++)
+                    _items.Add(new Item(br.ReadByte(), br.ReadByte())); //0x0B54 198 items (Item ID and Quantity)
                 Gametime = new TimeSpan(0, 0, (int)br.ReadUInt32());//0x0CE0
                 Countdown = br.ReadUInt32();//0x0CE4
                 Unknown3 = br.ReadUInt32();//0x0CE8
@@ -729,13 +732,10 @@ namespace OpenVIII
                 Module = br.ReadUInt16();//0x0D50 (1= field, 2= worldmap, 3= battle)
                 CurrentField = br.ReadUInt16();//0x0D52
                 PreviousField = br.ReadUInt16();//0x0D54
-                CoordX = new short[3];
                 for (int i = 0; i < 3; i++)
                     CoordX[i] = br.ReadInt16();//0x0D56 signed  (party1, party2, party3)
-                CoordY = new short[3];
                 for (int i = 0; i < 3; i++)
                     CoordY[i] = br.ReadInt16();//0x0D5C signed  (party1, party2, party3)
-                Triangle_ID = new ushort[3];
                 for (int i = 0; i < 3; i++)
                     Triangle_ID[i] = br.ReadUInt16();//0x0D62  (party1, party2, party3)
                 Direction = br.ReadBytes(3 * 1);//0x0D68  (party1, party2, party3)

--- a/Core/Saves/Saves.Data.cs
+++ b/Core/Saves/Saves.Data.cs
@@ -28,7 +28,8 @@ namespace OpenVIII
 
             private CharacterData GetDamageable(Characters id)
             {
-                if (Characters != null && !Characters.TryGetValue(id, out CharacterData c))
+                CharacterData c = null;
+                if (Characters != null && !Characters.TryGetValue(id, out c))
                 {
                     var ind = Party.FindIndex(x=>x.Equals(id));
 
@@ -36,7 +37,7 @@ namespace OpenVIII
                         throw new ArgumentException($"{this}::Cannot find {id} in CharacterData or Party");
                     return c;
                 }
-                return null;
+                return c;
             }
 
             private GFData GetDamageable(GFs id) => GFs.ContainsKey(id) ? GFs[id] : null;

--- a/Core/Saves/Saves.GFData.cs
+++ b/Core/Saves/Saves.GFData.cs
@@ -270,6 +270,7 @@ namespace OpenVIII
                 StatusImmune = true;
                 ID = g;
                 Name = br.ReadBytes(12);//0x00 (0x00 terminated)
+                if (string.IsNullOrWhiteSpace(Name)) Name = Memory.Strings.GetName(g);
                 Experience = br.ReadUInt32();//0x0C
                 Unknown = br.ReadByte();//0x10
                 Exists = br.ReadByte() == 1 ? true : false;//0x11 //1 unlocked //0 locked

--- a/Core/Saves/Saves.GFData.cs
+++ b/Core/Saves/Saves.GFData.cs
@@ -184,7 +184,7 @@ namespace OpenVIII
             /// <summary>
             /// Create a copy of this gfdata object
             /// </summary>
-            public GFData Clone()
+            public override Damageable Clone()
             {
                 //Shadowcopy
                 GFData c = (GFData)MemberwiseClone();

--- a/Core/World/module_world_debug.cs
+++ b/Core/World/module_world_debug.cs
@@ -623,7 +623,7 @@ namespace OpenVIII
                 if (shift != Vector2.Zero)
                 {
                     float angle = VectorToAngle(shift);
-                    Debug.WriteLine($"Shift: {shift} Angle: {MathHelper.ToDegrees(angle)} Camera: {degrees}");
+                    //Debug.WriteLine($"Shift: {shift} Angle: {MathHelper.ToDegrees(angle)} Camera: {degrees}");
                     playerPosition.X += (float)Math.Cos(MathHelper.ToRadians(MathHelper.ToDegrees(angle) + degrees - 90));
                     playerPosition.Z += (float)Math.Sin(MathHelper.ToRadians(MathHelper.ToDegrees(angle) + degrees - 90));
                     bHasMoved = true;


### PR DESCRIPTION
Removed Character and VisibleCharacter from Menu_Base replaced with Damageable. Damageable is the parent abstract class to Enemy, GFData, CharacterData. The idea being instead of keeping two enums that only works with ChracterData, we will now store a reference that can be used on any of them. Eventually I want to have debug menus controlling enemies maybe even give them a debug ATB bar and hp so we can see it work. Most of the commands are menu friendly. None of the background code is in yet though so the commands don't do anything yet except end turns.

I also fixed a couple bugs caused from this change and ones I didn't know were there. :)