### PR TITLE
Grammar improvements to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,31 +51,31 @@ Requirements: MonoGame + Visual Studio
 
 1. Download and install **Visual Studio 2017** (2015 is not supported) and **NET Framework 4.6**
 
-2. Clone whole repository:
+2. Clone the whole repository:
 
 `git clone https://github.com/MaKiPL/OpenVIII.git`
 
-3. Download and install **development build** of MonoGame:
+3. Download and install the **development build** of MonoGame:
 [MonoGame for Visual Studio](http://teamcity.monogame.net/repository/download/MonoGame_PackagingWindows/latest.lastSuccessful/MonoGameSetup.exe?guest=1)
 
-4. If you get "Unable to load DLL 'FreeImage'", Download and install:
+4. If you get an "Unable to load DLL 'FreeImage'" error, download and install:
 [Visual C++ Redistributable Packages for Visual Studio 2013](https://www.microsoft.com/en-us/download/details.aspx?id=40784)
 
-5. In Visual Studio 2017, while the solution is open, goto Tools > NuGet Package Manager > Manage NuGet Packages for solution. Make sure the required packages are installed and everything is up to date. There should be a notice on this screen if a package isn't installed. There will be a number in a box next to Updates if there are out of date packages.
+5. In Visual Studio 2017, while the solution is open, go to Tools > NuGet Package Manager > Manage NuGet Packages for solution. Make sure the required packages are installed and everything is up to date. There should be a notice on this screen if a package isn't installed. There will be a number in a box next to Updates if there are out of date packages.
 
-6. Make sure you add Final Fantasy VIII path to array at `WindowsGameLocationProvider.cs:36`. On Windows the code tries to detect the install path via the registry. If it fails, it'll fall back to the array.
+6. Make sure you add the Final Fantasy VIII path to the array at `WindowsGameLocationProvider.cs:36`. On Windows the code tries to detect the install path via the registry. If it fails, it'll fall back to the array.
 
 7. That's all. You can now compile the executable.
 
 ## Getting started (Linux/Mono) [Tested on Ubuntu]
 
-1. Make sure your Linux is up to date. Due to FFmpeg dependency we require Ubuntu Cosmos
+1. Make sure your Linux is up to date. Due to the FFmpeg dependency we require Ubuntu Cosmos.
 
 `sudo apt-get update`
 
 `sudo apt-get upgrade`
 
-2. Install latest MonoDevelop 
+2. Install the latest version of MonoDevelop 
 
 [MonoDevelop for Linux](https://www.monodevelop.com/download/#fndtn-download-lin)
 
@@ -97,7 +97,7 @@ Requirements: MonoGame + Visual Studio
 
 `git clone https://github.com/makipl/openviii`
 
-7. Open FF8.sln with MonoDevelop
+7. Open `FF8.sln` with MonoDevelop
 
 8. If you encounter missing `Microsoft.XNA...` then please open NuGet package **Edit/Packages/Add Package**:
 
@@ -107,13 +107,13 @@ Requirements: MonoGame + Visual Studio
 
 `MonoGame.Framework.OpenGL`
 
-9. Make sure you add Final Fantasy VIII path to array at `LinuxGameLocationProvider.cs:18`
+9. Make sure you add the Final Fantasy VIII path to the array at `LinuxGameLocationProvider.cs:18`
 
 10. That's all. You can now compile the executable.
 
 ## Development guidelines
 
-1. Project is in in-dev prototype, therefore you can make new pull requests directly to main branch. 
+1. Project is an in-dev prototype, therefore you can make new pull requests directly to main branch. 
 
 2. ??
 
@@ -128,4 +128,4 @@ PS. Required FFmpeg dlls. (available on Ubuntu Cosmos via `sudo apt-get install 
 * swresample-3.dll
 * swscale-5.dll
 <br/>
-I'd like to thanks everyone involved in this project!
+I'd like to thank everyone involved in this project!

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Requirements: MonoGame + Visual Studio
 
 1. Download and install **Visual Studio 2017** (2015 is not supported) and **NET Framework 4.6**
 
-2. Clone the whole repository:
+2. Clone the repository:
 
 `git clone https://github.com/MaKiPL/OpenVIII.git`
 
@@ -69,7 +69,7 @@ Requirements: MonoGame + Visual Studio
 
 ## Getting started (Linux/Mono) [Tested on Ubuntu]
 
-1. Make sure your Linux is up to date. Due to the FFmpeg dependency we require Ubuntu Cosmos.
+1. Make sure your Linux is up to date. Due to the FFmpeg dependency, we require Ubuntu Cosmos.
 
 `sudo apt-get update`
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,20 +2,20 @@
 
 ## What OpenVIII is?
 
-OpenVIII is an open-source complete **Final Fantasy VIII** game engine rewrite from scratch powered in OpenGL making it possible to play vanilla game on wide wariety of platforms including **Windows 32/64 bit**, **Linux 32/64 bit** and even **mobile**!
+OpenVIII is an open-source complete **Final Fantasy VIII** game engine rewrite from scratch powered in OpenGL making it possible to play the vanilla game on wide wariety of platforms including **Windows 32/64 bit**, **Linux 32/64 bit** and even **mobile**!
 
 ## Why was OpenVIII started?
 
-There are multiple answers to that questions: 
+There are multiple answers to that question: 
 * Modding possibilities were limited due to engine 16-bit approach including static memory locations. The PC engine implementation was unstable when modders tried to replace objects, models, textures with higher details and resolutions. 
 * Vanilla game engine used highly outdated technologies that forced the users to be able to play only on Windows. (On Linux user had to play with Wine)
 * Extreme resolutions like 4K, 8K, Eyefinity were impossible
-* FF Community contain a lot of amazing artists, but their works could not be imported into the game due to complexity and object handling- we wanted to change that and allow modders to be able to replace content using popular flie formats without worrying about poly count, BPP, palettes and more
-* The 20th birthday of the game resulted in almost no attention from the producer. All of the major games in the franchise were ported to other platforms leaving FFVIII the only game that was missing. The company didn't address any of the questions about leaving one of their child behind. Just recently the Final Fantasy VIII Remastered was announced finally keeping up with all the other games. This project was started long before that and is part of our love to the game.
+* FF Community contains a lot of amazing artists, but their works could not be imported into the game due to complexity and object handling - we wanted to change that and allow modders to be able to replace content using popular flie formats without worrying about poly count, BPP, palettes and more
+* The 20th birthday of the game resulted in almost no attention from the producer. All of the major games in the franchise were ported to other platforms leaving FFVIII the only game that was missing. The company didn't address any of the questions about leaving one of their children behind. Just recently Final Fantasy VIII Remastered was announced, finally keeping up with all the other games. This project was started long before that and is part of our love to the game.
 
 ## Is OpenVIII free? Is it legal?
 
-Yes. This project is free and open-source. It means you are able to look, modify and run the code without any charges. This project contains ONLY code that we wrote on our own. We CAN'T and we DON'T host any kind of asset that is licensed by **Square Enix**. We are in no way affiliated and/or related to the IP holders. This projects **REQUIRES** a full, legal copy of the Final Fantasy VIII game. This project is only our engine made to work with original files of the game. We do not support piracy. All our work is voluntary and we do not earn any money from it- no matter if directly or from donations. 
+Yes. This project is free and open-source. It means you are able to look at, modify and run the code without any charges. This project contains ONLY code that we wrote on our own. We CAN'T and we DON'T host any kind of asset that is licensed by **Square Enix**. We are in no way affiliated and/or related to the IP holders. This projects **REQUIRES** a full, legal copy of the Final Fantasy VIII game. This project is only our engine made to work with original files of the game. We do not support piracy. All our work is voluntary and we do not earn any money from it - no matter if directly or from donations. 
 
 ## Is Steam version enough to play with OpenVIII? Can I use PC2000 version?
 
@@ -23,27 +23,27 @@ Yes. The Steam release is the best option to be used with OpenVIII. Other than t
 
 ## Which game languages are available?
 
-Any that your game works on. OpenVIII is a game engine, we do not have any kind of text in our assets. Everything is read directly from your game catalogue. If you installed French version of the game, then OpenVIII will display the game in French.
+Any that your game works on. OpenVIII is a game engine: we do not have any kind of text in our assets. Everything is read directly from your game catalogue. If you installed French version of the game, then OpenVIII will display the game in French.
 
 ## What are the main NEW features of OpenVIII?
 
-Compared to vanilla Steam release so far we introduced these features:
+Compared to the vanilla Steam release so far we introduced these features:
 
 * Unlimited resolution - You can play in 64x64 up to 8k if your monitor supports it
-* Linux native support - You no longer have to play with Wine emulator. OpenVIII based on OpenGL delivers the game in native code- with direct support for your platform drivers. 
-* [WIP] Current known graphical mods support - We are succesfully introducing current vanilla mods supports including GUI/Menu overhaul, music replacement mods and more! We are in direct contact with all the mods authors planning how can we integrate their work
+* Linux native support - You no longer have to play with the Wine emulator. OpenVIII based on OpenGL delivers the game in native code - with direct support for your platform drivers. 
+* [WIP] Current known graphical mods support - We are succesfully introducing current vanilla mods supports including GUI/Menu overhaul, music replacement mods and more! We are in direct contact with all the mods authors planning how we can integrate their work.
 * [WIP] Current gen audio - You can now play DirectX Music segments on all platforms (WIP); We also natively support loopable OGG music replacements making it possible to change any music you want by simply drag&drop operation. Thanks to OpenVIII you will be able to change, edit, export to Midi .SGT segments, replace soundfonts and much more!
 * FFMPEG video module - Due to FFMPEG integration we are able to support wide amount of video formats. You are able to play .mp4, .bik and even replace the videos with your own without worrying about the codec. 
-* No more frame limits - All actions are no more tied to specific framerate. You can now enjoy the game with fully real-time animation blending making it possible to play the game in unlimited framerate making every motion smooth. [SEE IN ACTION!](https://www.youtube.com/watch?v=J9v_CpdkkPY)
+* No more frame limits - All actions are no more tied to a specific framerate. You can now enjoy the game with fully real-time animation blending making it possible to play the game in unlimited framerate making every motion smooth. [SEE IN ACTION!](https://www.youtube.com/watch?v=J9v_CpdkkPY)
 
 
 ## What are planned features for OpenVIII?
 
 Our main objective is to finish every single module to make the game fully playable from start to the end. Our second objective is to deliver the best and most user-friendly modding approach allowing non-tech users to be able to do what was always impossible. The main future features we want to introduce so far are:
 
-* Shader Model 3 - Every 3D scene would be enriched wit the possibility of real-time shadows, lightning and materials containing normal and specular maps.
-* Easy assets modding - with specialized toolking non-tech user would be able to replace ANY kind of game asset with a simple drag&drop operations not worrying about file format. We want the artists to be able to replace for example whole battle stage with high-poly FBX/OBJ exported without any addons straight from 3D modelling softwares. Same behaviour applicable to materials, textures and 2D art- no more complex file systems, worrying about palettes, proper BPP...
-* Android/iOS support- OpenVIII so far supports variety of inputs: keyboard, gamepads out-of-box and even playing with mouse! With that approach we would be able to introduce the smartphone version much faster
+* Shader Model 3 - Every 3D scene would be enriched with the possibility of real-time shadows, lightning and materials containing normal and specular maps.
+* Easy assets modding - with specialized tooling non-tech user would be able to replace ANY kind of game asset with simple drag&drop operations not worrying about file format. We want the artists to be able to replace for example the whole battle stage with high-poly FBX/OBJ exported without any addons straight from 3D modelling softwares. Same behaviour applicable to materials, textures and 2D art- no more complex file systems, worrying about palettes, proper BPP...
+* Android/iOS support- OpenVIII so far supports a variety of inputs: keyboard, gamepads out-of-box and even playing with the mouse! With that approach we would be able to introduce the smartphone version much faster
 
 
 # Current progress
@@ -55,4 +55,4 @@ Our main objective is to finish every single module to make the game fully playa
 
 # Contact
 
-If you need to contact us- please do so by making an issue on the github page or getting in touch via github profiles of project contributors. 
+If you need to contact us - please do so by making an issue on the github page or getting in touch via the github profiles of project contributors. 

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@ Yes. The Steam release is the best option to be used with OpenVIII. Other than t
 
 ## Which game languages are available?
 
-Any that your game works on. OpenVIII is a game engine: we do not have any kind of text in our assets. Everything is read directly from your game catalogue. If you installed French version of the game, then OpenVIII will display the game in French.
+Any that your game works on. OpenVIII is a game engine; we do not have any kind of text in our assets. Everything is read directly from your game catalogue. If you installed French version of the game, then OpenVIII will display the game in French.
 
 ## What are the main NEW features of OpenVIII?
 


### PR DESCRIPTION
Here's some improvements to the grammar of the documentation.

I was just passing through, looking at repos from GitHub Explore, when I noticed some missing articles and just had to fix them. I'm an editor at heart. :)

I've made some comments in the commit on edits I'm not certain about; please do take a look.

Disclaimer: I've never played FFVIII or worked on/played with this project (not yet anyway), so if one of my changes alters the meaning of the clause under concern in a way that contradicts with the prior meaning, I may not have noticed.
