### PR TITLE
Tidy up Camera and CameraStruct a bit. And fixed the Camera Shake.

### DIFF
--- a/Core/Battle/Camera/Camera.cs
+++ b/Core/Battle/Camera/Camera.cs
@@ -33,6 +33,8 @@ namespace OpenVIII.Battle
                 117,118,119,120,128,129,130,131,132,133,134,139,140,143,146,152,153,154,
                 155,156,159,161,162};
 
+        private bool Done;
+
         #endregion Fields
 
         //private BattleCameraSettings _battleCameraSettings;
@@ -111,12 +113,16 @@ namespace OpenVIII.Battle
 
         public void Update()
         {
-
-            (CamTarget, CamPosition, ViewMatrix, ProjectionMatrix) = Cam.UpdatePosition();
+            if(!Done || !Cam.Done)
+                (CamTarget, CamPosition, ViewMatrix, ProjectionMatrix) = Cam.UpdatePosition();
 
             if (Cam.Done)
             {
-                if (!BMultiShotAnimation || Cam.Time == 0) return;
+                if (!BMultiShotAnimation || Cam.Time == 0)
+                {
+                    Done = true;
+                    return;
+                }
                 using (var br = Stage.Open())
                     if (br != null)
                         ReadAnimation(LastCameraPointer - 2, br);
@@ -124,6 +130,7 @@ namespace OpenVIII.Battle
             else
             {
                 Cam.UpdateTime();
+                Done = false;
             }
         }
 

--- a/Core/Battle/Camera/Camera.cs
+++ b/Core/Battle/Camera/Camera.cs
@@ -1,11 +1,9 @@
 ﻿using Microsoft.Xna.Framework;
 using System;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
-using OpenVIII.Fields.Scripts.Instructions;
 
 namespace OpenVIII.Battle
 {
@@ -35,7 +33,7 @@ namespace OpenVIII.Battle
                 117,118,119,120,128,129,130,131,132,133,134,139,140,143,146,152,153,154,
                 155,156,159,161,162};
 
-        private bool Done;
+        private bool _done;
 
         #endregion Fields
 
@@ -115,13 +113,13 @@ namespace OpenVIII.Battle
 
         public void Update()
         {
-            if (!Done || !Cam.Done)
+            if (!_done || !Cam.Done)
             {
                 var tuple = Cam.UpdatePosition();
                 if (tuple.CamPosition != tuple.CamTarget)
                 {
                     (CamTarget, CamPosition, ViewMatrix, ProjectionMatrix) = tuple;
-                    Debug.WriteLine((CamTarget, CamPosition, ViewMatrix, ProjectionMatrix));
+                    //Debug.WriteLine((CamTarget, CamPosition, ViewMatrix, ProjectionMatrix));
                 }
             }
 
@@ -129,7 +127,7 @@ namespace OpenVIII.Battle
             {
                 if (!BMultiShotAnimation || Cam.Time == 0)
                 {
-                    Done = true;
+                    _done = true;
                     return;
                 }
                 using (var br = Stage.Open())
@@ -139,7 +137,7 @@ namespace OpenVIII.Battle
             else
             {
                 Cam.UpdateTime();
-                Done = false;
+                _done = false;
             }
         }
 

--- a/Core/Battle/Camera/Camera.cs
+++ b/Core/Battle/Camera/Camera.cs
@@ -1,9 +1,11 @@
 ﻿using Microsoft.Xna.Framework;
 using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using OpenVIII.Fields.Scripts.Instructions;
 
 namespace OpenVIII.Battle
 {
@@ -113,8 +115,15 @@ namespace OpenVIII.Battle
 
         public void Update()
         {
-            if(!Done || !Cam.Done)
-                (CamTarget, CamPosition, ViewMatrix, ProjectionMatrix) = Cam.UpdatePosition();
+            if (!Done || !Cam.Done)
+            {
+                var tuple = Cam.UpdatePosition();
+                if (tuple.CamPosition != tuple.CamTarget)
+                {
+                    (CamTarget, CamPosition, ViewMatrix, ProjectionMatrix) = tuple;
+                    Debug.WriteLine((CamTarget, CamPosition, ViewMatrix, ProjectionMatrix));
+                }
+            }
 
             if (Cam.Done)
             {

--- a/Core/Battle/Camera/CameraStruct.cs
+++ b/Core/Battle/Camera/CameraStruct.cs
@@ -1,8 +1,10 @@
 ﻿using Microsoft.Xna.Framework;
 using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.InteropServices;
+using OpenVIII.Fields.Scripts.Instructions;
 
 #pragma warning disable 169
 #pragma warning disable 649
@@ -87,15 +89,17 @@ namespace OpenVIII.Battle
             private static Vector3 Offset => new Vector3(40, 40, -40);
             //private (Vector3 World, Vector3 LookAt) this[int i] => (CameraWorld(i), CameraLookAt(i));
 
-            private Vector3 CameraWorld(int i) => new Vector3(
-                _cameraWorldX[i],
-                -(_cameraWorldY[i]),
-                -(_cameraWorldZ[i])) / Memory.CameraScale + Offset;
+            private Vector3 CameraWorld(int i) =>
+                new Vector3(
+                    _cameraWorldX[i],
+                    -(_cameraWorldY[i]),
+                    -(_cameraWorldZ[i])) / Memory.CameraScale + Offset;
 
-            private Vector3 CameraLookAt(int i) => new Vector3(
-                _cameraLookAtX[i],
-                -(_cameraLookAtY[i]),
-                -(_cameraLookAtZ[i])) / Memory.CameraScale + Offset;
+            private Vector3 CameraLookAt(int i) =>
+                new Vector3(
+                    _cameraLookAtX[i],
+                    -(_cameraLookAtY[i]),
+                    -(_cameraLookAtZ[i])) / Memory.CameraScale + Offset;
 
             public void UpdateTime() => CurrentTime += Memory.ElapsedGameTime;
 
@@ -252,7 +256,8 @@ namespace OpenVIII.Battle
                 CurrentTime = TimeSpan.Zero;
             }
 
-            public bool Done => CurrentTime >= TotalTime;
+            public bool Done => CurrentTime >= TotalTime || (_cameraLookAtX[0], _cameraLookAtY[0], _cameraLookAtZ[0],
+                _cameraWorldX[0], _cameraWorldY[0], _cameraWorldZ[0]) == (0, 0, 0, 0, 0, 0);
             public (Vector3 CamTarget, Vector3 CamPosition, Matrix View, Matrix Projection) UpdatePosition()
             {
                 var step = CurrentTime.Ticks / (float)TotalTime.Ticks;

--- a/Core/Battle/Camera/CameraStruct.cs
+++ b/Core/Battle/Camera/CameraStruct.cs
@@ -1,6 +1,11 @@
 ﻿using Microsoft.Xna.Framework;
 using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Runtime.InteropServices;
+
+#pragma warning disable 169
+#pragma warning disable 649
 
 namespace OpenVIII.Battle
 {
@@ -9,98 +14,265 @@ namespace OpenVIII.Battle
         #region Structs
 
         [StructLayout(LayoutKind.Sequential, Pack = 1, Size = 1092)]
+        [SuppressMessage("ReSharper", "UnassignedReadonlyField")]
+        [SuppressMessage("ReSharper", "UnusedMember.Global")]
         public struct CameraStruct
         {
-            public byte animationId; //000
-            public byte keyframeCount;
-            public ushort control_word;
-            public ushort startingFOV; //usually ~280
-            public ushort endingFOV; //006
-            public ushort startingCameraRoll; //usually 0 unless you're aiming for some wicked animation
-            public ushort endingCameraRoll; //
-            private ushort startingTime; //usually 0, that's pretty logical
+            public byte AnimationId { get; set; } //000
+            private byte KeyframeCount;
+            public ushort ControlWord { get; private set; }
+            public ushort StartingFov { get; private set; } //usually ~280
+            public ushort EndingFov { get; private set; } //006
+            private ushort StartingCameraRoll; //usually 0 unless you're aiming for some wicked animation
+            private ushort EndingCameraRoll; //
+            private readonly ushort _startingTime; //usually 0, that's pretty logical
 
             /// <summary>
             /// Time is calculated from number of frames. You basically set starting position
             /// World+lookat and ending position, then mark number of frames to interpolate between
-            /// them. Every frame is one drawcall and it costs 16.
+            /// them. Every frame is one draw call and it costs 16.
             /// </summary>
-            public ushort time; //starting time needs to be equal or higher for next animation frame to be read; If next frame==0xFFFF then it's all done
+            /// ReSharper disable once CommentTypo
+            /// <remarks>starting time needs to be equal or higher for next animation frame to be read; If next frame==0xFFFF then it's all done</remarks>
+            public ushort Time { get; private set; }
 
             [MarshalAs(UnmanagedType.ByValArray, SizeConst = 20)]
-            public byte[] unk; //010
+            private readonly byte[] _unkBytes; //010
 
             [MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
-            public ushort[] startFramesOffsets; //024 - start frames for each key frame?
+            private readonly ushort[] StartFramesOffsets; //024 - start frames for each key frame?
 
             [MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
-            public short[] Camera_World_Z_s16; //064
+            private readonly short[] _cameraWorldZ; //064
 
             [MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
-            public short[] Camera_World_X_s16; //0A4
+            private readonly short[] _cameraWorldX; //0A4
 
             [MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
-            public short[] Camera_World_Y_s16; //0E4
+            private readonly short[] _cameraWorldY; //0E4
 
             [MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
-            public byte[] is_FrameDurationsShot; //124
+            private readonly byte[] IsFrameDurationsShot; //124
 
             [MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
-            public short[] Camera_Lookat_Z_s16; //144
+            private readonly short[] _cameraLookAtZ; //144
 
             [MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
-            public short[] Camera_Lookat_X_s16; //184
+            private readonly short[] _cameraLookAtX; //184
 
             [MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
-            public short[] Camera_Lookat_Y_s16; //1C4
+            private readonly short[] _cameraLookAtY; //1C4
 
             [MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
-            public byte[] is_FrameEndingShots; //204
+            private readonly byte[] IsFrameEndingShots; //204
 
             [MarshalAs(UnmanagedType.ByValArray, SizeConst = 128)]
-            public byte[] unkbyte224; //224
+            private readonly byte[] _unkByte224; //224
 
             [MarshalAs(UnmanagedType.ByValArray, SizeConst = 128)]
-            public byte[] unkbyte2A4; //2A4
+            private readonly byte[] _unkByte2A4; //2A4
 
             [MarshalAs(UnmanagedType.ByValArray, SizeConst = 128)]
-            public byte[] unkbyte324; //324
+            private readonly byte[] _unkByte324; //324
 
             [MarshalAs(UnmanagedType.ByValArray, SizeConst = 128)]
-            public byte[] unkbyte3A4; //3A4
+            private readonly byte[] _unkByte3A4; //3A4
 
             [MarshalAs(UnmanagedType.ByValArray, SizeConst = 128)]
-            public byte[] unkbyte424; //424
+            private readonly byte[] _unkByte424; //424
 
             [MarshalAs(UnmanagedType.ByValArray, SizeConst = 128)]
-            public byte[] unkbyte4A4; //4A4
+            private readonly byte[] _unkByte4A4; //4A4
 
-            private float V => Memory.CameraScale;
+            private static Vector3 Offset => new Vector3(40, 40, -40);
+            //private (Vector3 World, Vector3 LookAt) this[int i] => (CameraWorld(i), CameraLookAt(i));
 
-            private Vector3 offset => new Vector3(40, 40, -40);
+            private Vector3 CameraWorld(int i) => new Vector3(
+                _cameraWorldX[i],
+                -(_cameraWorldY[i]),
+                -(_cameraWorldZ[i])) / Memory.CameraScale + Offset;
 
-            public Vector3 Camera_World(int i) => new Vector3(
-                Camera_World_X_s16[i],
-                -(Camera_World_Y_s16[i]),
-                -(Camera_World_Z_s16[i]))/V + offset;
-
-            public Vector3 Camera_Lookat(int i) => new Vector3(
-                Camera_Lookat_X_s16[i],
-                -(Camera_Lookat_Y_s16[i]),
-                -(Camera_Lookat_Z_s16[i]))/V + offset;
+            private Vector3 CameraLookAt(int i) => new Vector3(
+                _cameraLookAtX[i],
+                -(_cameraLookAtY[i]),
+                -(_cameraLookAtZ[i])) / Memory.CameraScale + Offset;
 
             public void UpdateTime() => CurrentTime += Memory.ElapsedGameTime;
 
-            public TimeSpan CurrentTime;
-            public TimeSpan TotalTime => TimeSpan.FromTicks(TotalTimePerFrame.Ticks * time);
+            public TimeSpan CurrentTime { get; private set; }
+
+            public TimeSpan TotalTime => TimeSpan.FromTicks(TotalTimePerFrame.Ticks * Time);
 
             /// <summary>
-            /// (1000) milliseconds / frames per second
+            /// (1000) milliseconds / frames per second, maybe not quite fps.
             /// </summary>
-            public TimeSpan TotalTimePerFrame => TimeSpan.FromMilliseconds(1000d / 240d);
+            private static TimeSpan TotalTimePerFrame => TimeSpan.FromMilliseconds(1000d / 240d);
 
             public void ResetTime() => CurrentTime = TimeSpan.Zero;
-        };
+
+            public void ReadAnimation(BinaryReader br)
+            {
+                ControlWord = br.ReadUInt16();
+                if (ControlWord == 0xFFFF) return;
+
+                var currentPosition = br.ReadUInt16(); //getter for *current_position
+                br.BaseStream.Seek(-2, SeekOrigin.Current); //roll back one WORD because no increment
+
+                switch ((ControlWord >> 6) & 3)
+                {
+                    case 1:
+                        StartingFov = 0x200;
+                        EndingFov = 0x200;
+                        break;
+
+                    case 2:
+                        StartingFov = currentPosition;
+                        EndingFov = currentPosition;
+                        br.ReadUInt16(); //current_position++
+                        break;
+
+                    case 3:
+                        StartingFov = currentPosition;
+                        br.BaseStream.Seek(2,
+                            SeekOrigin
+                                .Current); //skipping WORD, because we already rolled back one WORD above this switch
+                        currentPosition = br.ReadUInt16();
+                        EndingFov = currentPosition;
+                        break;
+                }
+
+                switch ((ControlWord >> 8) & 3)
+                {
+                    case 0: //TODO!!
+                        StartingCameraRoll = 00000000; //TODO, what's ff8vars.unkWord1D977A2?
+                        EndingCameraRoll = 00000000; //same as above; cam->unkWord00A = ff8vars.unkWord1D977A2;
+                        break;
+
+                    case 1:
+                        StartingCameraRoll = 0;
+                        EndingCameraRoll = 0;
+                        break;
+
+                    case 2:
+                        currentPosition = br.ReadUInt16(); //* + current_position++;
+                        StartingCameraRoll = currentPosition;
+                        EndingCameraRoll = currentPosition;
+                        break;
+
+                    case 3:
+                        currentPosition = br.ReadUInt16(); //* + current_position++;
+                        StartingCameraRoll = currentPosition;
+                        currentPosition = br.ReadUInt16(); //* + current_position++;
+                        EndingCameraRoll = currentPosition;
+                        break;
+                }
+
+                byte keyFrameCount = 0;
+                ushort totalFrameCount = 0;
+                switch (ControlWord & 1)
+                {
+                    case 0:
+                        while (true
+                        ) //I'm setting this to true and breaking in code as this works on peeking on next variable via pointer and that's not possible here without unsafe block
+                        {
+                            StartFramesOffsets[keyFrameCount] = totalFrameCount; //looks like this is the camera index
+                            currentPosition = br.ReadUInt16();
+                            if ((short)currentPosition < 0
+                            ) //reverse of *current_position >= 0, also cast to signed is important here
+                                break;
+                            totalFrameCount +=
+                                (ushort)(currentPosition *
+                                          16); //here is increment of short*, but I already did that above
+                            IsFrameDurationsShot[keyFrameCount] =
+                                (byte)(br
+                                    .ReadUInt16()
+                                ); //cam->unkByte124[keyFrameCount] = *current_position++; - looks like we are wasting one byte due to integer sizes
+                            _cameraWorldX[keyFrameCount] = (short)(br.ReadUInt16());
+                            _cameraWorldY[keyFrameCount] = (short)(br.ReadUInt16());
+                            _cameraWorldZ[keyFrameCount] = (short)(br.ReadUInt16());
+                            IsFrameEndingShots[keyFrameCount] =
+                                (byte)(br.ReadUInt16()); //m->unkByte204[keyFrameCount] = *current_position++;
+                            _cameraLookAtX[keyFrameCount] = (short)(br.ReadUInt16());
+                            _cameraLookAtY[keyFrameCount] = (short)(br.ReadUInt16());
+                            _cameraLookAtZ[keyFrameCount] = (short)(br.ReadUInt16());
+                            keyFrameCount++;
+                        }
+
+                        if (keyFrameCount > 2)
+                        {
+                            //ff8Functions.Sub50D010(cam->unkWord024, cam->unkWord064, cam->unkWord0A4, cam->unkWord0E4, keyFrameCount, cam->unkByte224, cam->unkByte2A4, cam->unkByte324);
+                            //ff8Functions.Sub50D010(cam->unkWord024, cam->unkWord144, cam->unkWord184, cam->unkWord1C4, keyFrameCount, cam->unkByte3A4, cam->unkByte424, cam->unkByte4A4);
+                        }
+
+                        break;
+
+                    case 1:
+                        {
+                            goto case 0;
+                            //if (currentPosition >= 0)
+                            //{
+                            //    var local14 = (short)(br.BaseStream.Position + 5 * 2);
+                            //    var local10 = (short)(br.BaseStream.Position + 6 * 2);
+                            //    var local2C = (short)(br.BaseStream.Position + 7 * 2);
+                            //    var local18 = (short)(br.BaseStream.Position + 1 * 2);
+                            //    var local1C = (short)(br.BaseStream.Position + 2 * 2);
+                            //    while (true)
+                            //    {
+                            //        StartFramesOffsets[keyFrameCount] = totalFrameCount;
+                            //        currentPosition = br.ReadUInt16();
+                            //        if ((short)currentPosition < 0) //reverse of *current_position >= 0, also cast to signed is important here
+                            //            break;
+                            //        totalFrameCount += (ushort)(currentPosition * 16);
+                            //        //ff8Functions.Sub503AE0(++local18, ++local1C, ++ebx, *(BYTE*)current_position, &cam->unkWord064[keyFrameCount], &cam->unkWord0A4[keyFrameCount], &cam->unkWord0E4[keyFrameCount]);
+                            //        //ff8Functions.Sub503AE0(++local14, ++local10, ++local2C, *(BYTE*)(current_position + 4), &cam->unkWord144[keyFrameCount], &cam->unkWord184[keyFrameCount], &cam->unkWord1C4[keyFrameCount]);
+                            //        IsFrameEndingShots[keyFrameCount] = 0xFB;
+                            //        IsFrameDurationsShot[keyFrameCount] = 0xFB;
+                            //        local1C += 8;
+                            //        local18 += 8;
+                            //        currentPosition += 8;
+                            //        local2C += 8;
+                            //        //ebx += 8;
+                            //        local10 += 8;
+                            //        local14 += 8;
+                            //        keyFrameCount++;
+                            //    }
+                            //}
+                            //break;
+                        }
+                }
+
+                if ((ControlWord & 0x3E) == 0x1E)
+                {
+                    //ff8Functions.Sub503300();
+                }
+
+                KeyframeCount = keyFrameCount;
+                Time = totalFrameCount;
+                //cam.startingTime = 0;
+                CurrentTime = TimeSpan.Zero;
+            }
+
+            public bool Done => CurrentTime >= TotalTime;
+            public (Vector3 CamTarget, Vector3 CamPosition, Matrix View, Matrix Projection) UpdatePosition()
+            {
+                var step = CurrentTime.Ticks / (float)TotalTime.Ticks;
+                var camTarget = Vector3.SmoothStep(CameraLookAt(20), CameraLookAt(1), step);
+                var camPosition = Vector3.SmoothStep(CameraWorld(0), CameraWorld(1), step);
+                var fov =
+                    MathHelper.ToRadians(
+                        (float)(2f * Math.Atan(240f / (2f *
+                                 MathHelper.SmoothStep(StartingFov, EndingFov, step))) *
+                                 57.29577951f));
+                var viewMatrix = Matrix.CreateLookAt(camPosition, camTarget, Vector3.Up);
+
+                var projectionMatrix = (Memory.Graphics != null)
+                    ? Matrix.CreatePerspectiveFieldOfView(fov,
+                        Memory.Graphics.GraphicsDevice.Viewport.AspectRatio, 1f, 1000f)
+                    : Matrix.Identity;
+
+                return (camTarget, camPosition, viewMatrix, projectionMatrix);
+            }
+        }
 
         #endregion Structs
     }

--- a/Core/Battle/Camera/CameraStruct.cs
+++ b/Core/Battle/Camera/CameraStruct.cs
@@ -256,7 +256,8 @@ namespace OpenVIII.Battle
             public (Vector3 CamTarget, Vector3 CamPosition, Matrix View, Matrix Projection) UpdatePosition()
             {
                 var step = CurrentTime.Ticks / (float)TotalTime.Ticks;
-                var camTarget = Vector3.SmoothStep(CameraLookAt(20), CameraLookAt(1), step);
+                if (step > 1f) step = 1f;
+                var camTarget = Vector3.SmoothStep(CameraLookAt(0), CameraLookAt(1), step);
                 var camPosition = Vector3.SmoothStep(CameraWorld(0), CameraWorld(1), step);
                 var fov =
                     MathHelper.ToRadians(

--- a/Core/Battle/Camera/CameraStruct.cs
+++ b/Core/Battle/Camera/CameraStruct.cs
@@ -1,10 +1,8 @@
 ﻿using Microsoft.Xna.Framework;
 using System;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.InteropServices;
-using OpenVIII.Fields.Scripts.Instructions;
 
 #pragma warning disable 169
 #pragma warning disable 649
@@ -258,6 +256,7 @@ namespace OpenVIII.Battle
 
             public bool Done => CurrentTime >= TotalTime || (_cameraLookAtX[0], _cameraLookAtY[0], _cameraLookAtZ[0],
                 _cameraWorldX[0], _cameraWorldY[0], _cameraWorldZ[0]) == (0, 0, 0, 0, 0, 0);
+
             public (Vector3 CamTarget, Vector3 CamPosition, Matrix View, Matrix Projection) UpdatePosition()
             {
                 var step = CurrentTime.Ticks / (float)TotalTime.Ticks;

--- a/Core/Battle/ModuleBattleDebug.cs
+++ b/Core/Battle/ModuleBattleDebug.cs
@@ -179,7 +179,7 @@ namespace OpenVIII
                     DrawMonsters();
                     DrawCharactersWeapons();
                     _regularPyramid.Draw(WorldMatrix, ViewMatrix, ProjectionMatrix);
-                    Stage.Draw();
+                    Stage?.Draw();
                     var v = GetIndicatorPoint(-1);
                     v.Y -= 5f;
                     if (!_bUseFPSCamera)
@@ -205,11 +205,11 @@ namespace OpenVIII
             ImGui.Text($"Debug variable: {DebugFrame} ({DebugFrame >> 4},{DebugFrame & 0b1111})\n");
             ImGui.Text($"1000/deltaTime milliseconds: {(Memory.ElapsedGameTime.TotalSeconds > 0 ? 1d / Memory.ElapsedGameTime.TotalSeconds : 0d)}\n");
             ImGui.Text($"Average FrameRate: {FPSCounter.AverageFramesPerSecond}\n");
-            ImGui.Text($"camera frame: {Camera.cam.CurrentTime}/{Camera.cam.TotalTime}\n");
+            ImGui.Text($"camera frame: {Camera.Cam.CurrentTime}/{Camera.Cam.TotalTime}\n");
             ImGui.Text($"Camera.World.Position: {Extended.RemoveBrackets(_camPosition.ToString())}\n");
             ImGui.Text($"Camera.World.Target: {Extended.RemoveBrackets(_camTarget.ToString())}\n");
-            ImGui.Text($"Camera.FOV: {MathHelper.Lerp(Camera.cam.startingFOV, Camera.cam.endingFOV, Camera.cam.CurrentTime.Ticks / (float)Camera.cam.TotalTime.Ticks)}\n");
-            ImGui.Text($"Camera.Mode: {Camera.cam.control_word & 1}\n");
+            ImGui.Text($"Camera.FOV: {MathHelper.Lerp(Camera.Cam.StartingFov, Camera.Cam.EndingFov, Camera.Cam.CurrentTime.Ticks / (float)Camera.Cam.TotalTime.Ticks)}\n");
+            ImGui.Text($"Camera.Mode: {Camera.Cam.ControlWord & 1}\n");
             ImGui.Text($"DEBUG: Press 0 to switch between FPSCamera/Camera anim: {_bUseFPSCamera}\n");
             ImGui.Text($"Sequence ID: {_sid}, press F10 to activate sequence, F11 SID--, F12 SID++");
             ImGui.End();
@@ -269,7 +269,7 @@ namespace OpenVIII
                     DebugFrame -= 7;
                 }
                 else DebugFrame += 1;
-                Camera.ChangeAnimation((byte)DebugFrame);
+                Camera.ChangeAnimation((byte)Math.Abs(DebugFrame));
             }
             else if (Input2.Button(Keys.D2))
             {
@@ -279,7 +279,7 @@ namespace OpenVIII
                     DebugFrame += 7;
                 }
                 else DebugFrame--;
-                Camera.ChangeAnimation((byte)DebugFrame);
+                Camera.ChangeAnimation((byte)Math.Abs(DebugFrame));
             }
             else if (Input2.Button(Keys.F5))
             {
@@ -439,15 +439,15 @@ namespace OpenVIII
                     if (_bUseFPSCamera)
                     {
                         ViewMatrix = _fpsCamera.Update(ref _camPosition, ref _camTarget, ref _degrees);
-                        ProjectionMatrix = Camera.projectionMatrix;
+                        ProjectionMatrix = Camera.ProjectionMatrix;
                     }
                     else
                     {
                         if (Camera != null)
                         {
                             Camera.Update();
-                            ViewMatrix = Camera.viewMatrix;
-                            ProjectionMatrix = Camera.projectionMatrix;
+                            ViewMatrix = Camera.ViewMatrix;
+                            ProjectionMatrix = Camera.ProjectionMatrix;
                         }
 
                         ret = Menu.BattleMenus.Inputs();

--- a/Core/Field/JSM/File/Jsm.File.Header.cs
+++ b/Core/Field/JSM/File/Jsm.File.Header.cs
@@ -11,27 +11,27 @@ namespace OpenVIII.Fields.Scripts
             #region Structs
 
             [StructLayout(LayoutKind.Explicit, Size = 8, Pack = 1)]
-            public struct Header
+            public readonly struct Header
             {
                 #region Fields
 
                 [field: FieldOffset(0)]
-                public byte CountAreas;
+                public readonly byte CountAreas;
 
                 [field: FieldOffset(1)]
-                public byte CountDoors;
+                public readonly byte CountDoors;
 
                 [field: FieldOffset(2)]
-                public byte CountModules;
+                public readonly byte CountModules;
 
                 [field: FieldOffset(3)]
-                public byte CountObjects;
+                public readonly byte CountObjects;
 
                 [field: FieldOffset(6)]
-                public ushort OperationsOffset;
+                public readonly ushort OperationsOffset;
 
                 [field: FieldOffset(4)]
-                public ushort ScriptsOffset;
+                public readonly ushort ScriptsOffset;
 
                 #endregion Fields
             };


### PR DESCRIPTION
### Camera
 - Moved most of the code that sets values in the Camera Struct into the struct.
 - Moved code that gets current camera position and direction into the Camera Struct.
 - Ignore values if Camera Position == Camera Target.
### Camera Struct
 - Check for starting XYZ for target and world for 0 values. Maybe this is how FF8 sets camera animation to be done. We were just checking for `CurrentTime >= TotalTime` But then we'd have a approx 7 frames of bad animation causing a shake to happen.
 - Set values that don't change to readonly and anything that isn't changed outside of the struct is `private set`.